### PR TITLE
#358 v2 affiliation list dropdown

### DIFF
--- a/climmob/config/routes.py
+++ b/climmob/config/routes.py
@@ -165,7 +165,7 @@ from climmob.views.basic_views import (
     PrivacyView,
 )
 from climmob.views.cleanErrorLogs import CleanErrorLogsView
-from climmob.views.cloneProjects.cloneProjects import cloneProjects_view
+from climmob.views.cloneProjects.cloneProjects import CloneProjectsView
 from climmob.views.dashboard import dashboard_view, projectInformation_view
 from climmob.views.editData import (
     editDataView,
@@ -1332,7 +1332,7 @@ def loadRoutes(config):
         {
             "name": "cloneProject",
             "path": "/cloneProject",
-            "view": cloneProjects_view,
+            "view": CloneProjectsView,
             "renderer": "cloneProjects/cloneProjects.jinja2",
         }
     )

--- a/climmob/config/routes.py
+++ b/climmob/config/routes.py
@@ -201,12 +201,12 @@ from climmob.views.productsList import (
 )
 from climmob.views.profile import profile_view, editProfile_view
 from climmob.views.project import (
-    newProject_view,
-    getTemplatesByTypeOfProject_view,
-    modifyProject_view,
-    deleteProject_view,
-    projectList_view,
-    CurationOfProjects_view,
+    NewProjectView,
+    GetTemplatesByTypeOfProjectView,
+    ModifyProjectView,
+    DeleteProjectView,
+    ProjectListView,
+    CurationOfProjectsView,
     GetUnitOfAnalysisByLocationView,
     GetObjectivesByLocationAndUnitOfAnalysisView,
 )
@@ -423,7 +423,7 @@ def loadRoutes(config):
         {
             "name": "projectList",
             "path": "/projectList",
-            "view": projectList_view,
+            "view": ProjectListView,
             "renderer": "project/projectList.jinja2",
         }
     )
@@ -483,7 +483,7 @@ def loadRoutes(config):
         addRoute(
             "getTemplatesByTypeOfProject",
             "/projectType/{typeid}",
-            getTemplatesByTypeOfProject_view,
+            GetTemplatesByTypeOfProjectView,
             "json",
         )
     )
@@ -492,7 +492,7 @@ def loadRoutes(config):
         {
             "name": "newproject",
             "path": "/project/new",
-            "view": newProject_view,
+            "view": NewProjectView,
             "renderer": "project/newproject.jinja2",
         }
     )
@@ -500,7 +500,7 @@ def loadRoutes(config):
         {
             "name": "modifyproject",
             "path": "/user/{user}/project/{project}/edit",
-            "view": modifyProject_view,
+            "view": ModifyProjectView,
             "renderer": "project/modifyproject.jinja2",
         }
     )
@@ -508,7 +508,7 @@ def loadRoutes(config):
         {
             "name": "deleteproject",
             "path": "/user/{user}/project/{project}/delete",
-            "view": deleteProject_view,
+            "view": DeleteProjectView,
             "renderer": "json",
         }
     )
@@ -818,7 +818,7 @@ def loadRoutes(config):
         addRoute(
             "curationofprojects",
             "/CurationOfProjects",
-            CurationOfProjects_view,
+            CurationOfProjectsView,
             "project/curationofprojects.jinja2",
         )
     )

--- a/climmob/processes/db/affiliation.py
+++ b/climmob/processes/db/affiliation.py
@@ -28,6 +28,10 @@ def search_affiliation(request, q, query_from, query_size):
 
 def get_all_affiliations(request):
 
-    result = mapFromSchema(request.dbsession.query(Affiliation).all())
+    result = mapFromSchema(
+        request.dbsession.query(Affiliation)
+        .order_by(Affiliation.affiliation_name)
+        .all()
+    )
 
     return result

--- a/climmob/templates/snippets/project/project_form.jinja2
+++ b/climmob/templates/snippets/project/project_form.jinja2
@@ -62,11 +62,18 @@
                     <div class="form-group">
                         <label class="col-sm-4 control-label">{{ _("Affiliation") }}</label>
                         <div class="col-sm-8">
-                            <select id="project_affiliation" name="project_affiliation" class="form-control js-example-data-ajax" required oninvalid="this.setCustomValidity('{{ _("Write the affiliation.") }}')" onchange="this.setCustomValidity('')" {% if not permissionForChanges %} disabled {% endif %}>
-                                {% if dataworking.project_affiliation %}
-                                    <option value="{{ dataworking.project_affiliation }}">{{ dataworking.project_affiliation }}</option>
+                            <select id="project_affiliation" name="project_affiliation" class="form-control js-affiliation-tags" required oninvalid="this.setCustomValidity('{{ _("Write the affiliation.") }}')" onchange="this.setCustomValidity('')" {% if not permissionForChanges %} disabled {% endif %}>
+                                <option value="">{{ _("Select one or create a new affiliation") }}</option>
+
+                                {% for affiliation in list_of_affiliation %}
+                                    <option value="{{ affiliation.affiliation_name }}" {% if affiliation.affiliation_name == dataworking.project_affiliation %}selected{% endif %}>{{ affiliation.affiliation_name }}</option>
+                                {% endfor %}
+                                {% if list_of_affiliation | selectattr("affiliation_name", "equalto", dataworking.project_affiliation) | list | length <= 0%}
+                                <option value="{{ dataworking.project_affiliation }}" selected>{{ dataworking.project_affiliation }}</option>
                                 {% endif %}
+
                             </select>
+
                         </div>
                     </div>
                     <br>
@@ -381,39 +388,19 @@
 
     $('.chosen-select').select2({width: "100%", maximumSelectionLength: 4});
 
-    $(".js-example-data-ajax").select2({
-        placeholder: "{{ _("Write the affiliation name") }}",
-        ajax: {
-            url: "{{ request.route_url('searchaffiliation') }}",
-            dataType: 'json',
-            delay: 250,
-            data: function (params) {
-                return {
-                    q: params.term, // search term
-                    page: params.page
-                };
-            },
-            processResults: function (data, params) {
-                params.page = params.page || 1;
 
-                if (data.results.length === 0 && params.term) {
-                    data.results.push({
-                        id: params.term,
-                        text: "{{ _("New affiliation") }}: "+params.term,
-                    });
+    $(".js-affiliation-tags").select2({
+            tags: true,
+            createTag: function (params) {
+                const term = $.trim(params.term);
+                if (term === '') return null;
+
+                return {
+                    id: params.term,
+                    text: "{{ _("New affiliation") }}: " + params.term,
                 }
-
-                return {
-                    results: data.results,
-                    pagination: {
-                        more: (params.page * 10) < data.total
-                    }
-                };
-            },
-            cache: true
-        }
+            }
     });
-
 
     function showHelpTem()
     {

--- a/climmob/templates/snippets/project/project_form.jinja2
+++ b/climmob/templates/snippets/project/project_form.jinja2
@@ -62,14 +62,19 @@
                     <div class="form-group">
                         <label class="col-sm-4 control-label">{{ _("Affiliation") }}</label>
                         <div class="col-sm-8">
-                            <select id="project_affiliation" name="project_affiliation" class="form-control js-affiliation-tags" required oninvalid="this.setCustomValidity('{{ _("Write the affiliation.") }}')" onchange="this.setCustomValidity('')" {% if not permissionForChanges %} disabled {% endif %}>
-                                <option value="">{{ _("Select one or create a new affiliation") }}</option>
-
+                            <select id="project_affiliation" name="project_affiliation" class="form-control js-affiliation-tags" required oninvalid="this.setCustomValidity('{{ _("Select or create a new affiliation.") }}')" onchange="this.setCustomValidity('')" {% if not permissionForChanges %} disabled {% endif %}>
+                                {% if not dataworking.project_affiliation %}
+                                    <option value="" selected>
+                                        {{ _("Select one or create a new affiliation") }}
+                                    </option>
+                                {% endif %}
                                 {% for affiliation in list_of_affiliation %}
                                     <option value="{{ affiliation.affiliation_name }}" {% if affiliation.affiliation_name == dataworking.project_affiliation %}selected{% endif %}>{{ affiliation.affiliation_name }}</option>
                                 {% endfor %}
-                                {% if list_of_affiliation | selectattr("affiliation_name", "equalto", dataworking.project_affiliation) | list | length <= 0%}
-                                <option value="{{ dataworking.project_affiliation }}" selected>{{ dataworking.project_affiliation }}</option>
+                                {% if dataworking.project_affiliation %}
+                                    {% if list_of_affiliation | selectattr("affiliation_name", "equalto", dataworking.project_affiliation) | list | length <= 0%}
+                                        <option value="{{ dataworking.project_affiliation }}" selected>{{ dataworking.project_affiliation }}</option>
+                                    {% endif %}
                                 {% endif %}
 
                             </select>

--- a/climmob/tests/test_utils/test_views_clone_projects_clone_projects.py
+++ b/climmob/tests/test_utils/test_views_clone_projects_clone_projects.py
@@ -1,0 +1,474 @@
+from unittest.mock import patch, MagicMock, ANY, call
+
+from fontTools.misc.cython import returns
+from pyramid.httpexceptions import HTTPNotFound, HTTPFound
+
+from climmob.tests.test_utils.common import BaseViewTestCase
+from climmob.views.cloneProjects.cloneProjects import CloneProjectsView
+
+
+class TestModifyProjectView(BaseViewTestCase):
+    view_class = CloneProjectsView
+    request_method = "POST"
+
+    def setup(self):
+        super().setUp()
+        self.view.request.registry.settings = {"projects.limit": "false"}
+
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getTotalNumberOfProjectsInClimMob",
+        return_value=0,
+    )
+    def test_process_view_clone_projects_view_project_limits_true(
+        self, mock_get_total_number_of_projects_in_climmob
+    ):
+        self.view.request.registry.settings = {
+            "projects.limit": "true",
+            "projects.quantity": 0,
+        }
+        with self.assertRaises(HTTPNotFound) as context:
+            self.view.processView()
+        self.assertEqual(context.exception.code, 404)
+        mock_get_total_number_of_projects_in_climmob.assert_called_once_with(
+            self.view.request
+        )
+
+    def test_process_view_clone_project_view_stage_error(self):
+        self.view.request.params = {"stage": "0"}
+        with self.assertRaises(HTTPNotFound) as context:
+            self.view.processView()
+        self.assertEqual(context.exception.code, 404)
+
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.projectExists", return_value=False
+    )
+    def test_process_view_clone_project_view_stage_not_1_project_not_exist(
+        self, mock_project_exists
+    ):
+        self.view.request.params = {
+            "stage": "2",
+            "project": "CLIMMOB",
+            "user": "test_user",
+        }
+
+        with self.assertRaises(HTTPNotFound) as context:
+            self.view.processView()
+            self.assertEqual(context.exception.code, 404)
+        mock_project_exists.assert_called_once_with(
+            self.view.user.login, "test_user", "CLIMMOB", self.view.request
+        )
+
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.projectExists", return_value=False
+    )
+    def test_process_view_clone_project_view_stage_1_success(self, mock_project_exists):
+        self.view.request.params = {
+            "stage": "1",
+            "project": "CLIMMOB",
+            "user": "test_user",
+        }
+        self.view.request.POST = {"slt_project_by_owner": "test_user___CLIMMOB"}
+        self.view.request.route_url = MagicMock(
+            return_value="/cloneProject?stage=2&project=my_project&user=test_user"
+        )
+        result = self.view.processView()
+        self.assertIsInstance(result, HTTPFound)
+        self.assertEqual(
+            result.location, "/cloneProject?stage=2&project=my_project&user=test_user"
+        )
+        mock_project_exists.assert_called_once_with(
+            self.view.user.login, "test_user", "CLIMMOB", self.view.request
+        )
+
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getUserProjects",
+        return_value={"data": "data"},
+    )
+    @patch("climmob.views.cloneProjects.cloneProjects.getActiveProject", return_value=1)
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.projectExists", return_value=False
+    )
+    def test_process_view_clone_project_view_stage_1_error(
+        self, mock_project_exists, mock_get_active_project, mock_get_user_projects
+    ):
+        self.view.request.params = {
+            "stage": "1",
+            "project": "CLIMMOB",
+            "user": "test_user",
+        }
+        self.view.request.method = "GET"
+
+        self.view.request.route_url = MagicMock(
+            return_value="/cloneProject?stage=2&project=CLIMMOB&user=test_user"
+        )
+        result = self.view.processView()
+        self.assertEqual(
+            result,
+            {
+                "activeProject": 1,
+                "dataworking": {
+                    "structureToBeCloned": "",
+                    "slt_project_by_owner": "test_user___CLIMMOB",
+                },
+                "projects": {"data": "data"},
+                "stage": 1,
+            },
+        )
+        mock_project_exists.assert_called_once_with(
+            self.view.user.login, "test_user", "CLIMMOB", self.view.request
+        )
+        mock_get_active_project.assert_called_once_with(
+            self.view.user.login, self.view.request
+        )
+        mock_get_user_projects.assert_called_once_with(
+            self.view.user.login, self.view.request
+        )
+
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getUserProjects",
+        return_value={"data1": "data1"},
+    )
+    @patch("climmob.views.cloneProjects.cloneProjects.getActiveProject", return_value=1)
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getAllInformationForProject",
+        return_value={"data": "data"},
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getTheProjectIdForOwner",
+        return_value=1,
+    )
+    @patch("climmob.views.cloneProjects.cloneProjects.projectExists", return_value=True)
+    def test_process_view_clone_project_view_stage_2_success(
+        self,
+        mock_project_exists,
+        mock_get_the_project_id_for_owner,
+        mock_get_all_information_for_project,
+        mock_get_active_project,
+        mock_get_user_projects,
+    ):
+        self.view.request.params = {
+            "stage": "2",
+            "project": "CLIMMOB",
+            "user": "test_user",
+        }
+        result = self.view.processView()
+        self.assertEqual(
+            result,
+            {
+                "activeProject": 1,
+                "dataworking": {
+                    "structureToBeCloned": "",
+                    "slt_project_by_owner": "test_user___CLIMMOB",
+                    "projectBeingCloned": {"data": "data"},
+                },
+                "projects": {"data1": "data1"},
+                "stage": 2,
+            },
+        )
+        mock_project_exists.assert_called_once_with(
+            self.view.user.login, "test_user", "CLIMMOB", self.view.request
+        )
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "test_user", "CLIMMOB", self.view.request
+        )
+        mock_get_all_information_for_project.assert_called_once_with(
+            self.view, "test_user", 1
+        )
+        mock_get_active_project.assert_called_once_with(
+            self.view.user.login, self.view.request
+        )
+        mock_get_user_projects.assert_called_once_with(
+            self.view.user.login, self.view.request
+        )
+
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.function_create_clone",
+        return_value="",
+    )
+    @patch("climmob.views.cloneProjects.cloneProjects.create_project_function")
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getTheProjectIdForOwner",
+        return_value=1,
+    )
+    @patch("climmob.views.cloneProjects.cloneProjects.projectExists", return_value=True)
+    def test_process_view_clone_project_view_stage_3_success(
+        self,
+        mock_project_exists,
+        mock_get_the_project_id_for_owner,
+        mock_create_project_function,
+        mock_function_create_clone,
+    ):
+        self.view.request.params = {
+            "stage": "3",
+            "project": "CLIMMOB",
+            "user": "test_user",
+        }
+        self.view.request.POST = {
+            "btn_addNewProject": "1",
+            "project_cod": "CLIMMOB",
+            "structureToBeCloned": "SOME_VALUE,OTHER_VALUE",
+        }
+        mock_create_project_function.return_value = (
+            {"project_cod": "CLIMMOB", "structureToBeCloned": "SOME_VALUE,OTHER_VALUE"},
+            {},
+            True,
+        )
+        self.view.request.route_url = MagicMock(
+            return_value="/cloneProject?stage=4&project=CLIMMOB&user=test_user"
+        )
+        result = self.view.processView()
+        self.assertIsInstance(result, HTTPFound)
+        self.assertEqual(
+            result.location, "/cloneProject?stage=4&project=CLIMMOB&user=test_user"
+        )
+        mock_project_exists.assert_called_once_with(
+            self.view.user.login, "test_user", "CLIMMOB", self.view.request
+        )
+        mock_get_the_project_id_for_owner.assert_called_with(
+            "test_user", "CLIMMOB", self.view.request
+        )
+        mock_create_project_function.assert_called_once_with(ANY, {}, self.view)
+        mock_function_create_clone.assert_called_once_with(
+            self.view, 1, 1, ["SOME_VALUE", "OTHER_VALUE"]
+        )
+
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.get_all_affiliations",
+        return_value="AFFILIATION",
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.get_all_objectives_by_location_and_unit_of_analysis",
+        return_value="ALL_OBJECTIVES_BY_LOCATION_AND_UNIT_OF_ANALYSIS",
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.get_all_unit_of_analysis_by_location",
+        return_value="ALL_UNIT_OF_ANALYSIS_BY_LOCATION",
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.get_all_project_location",
+        return_value="ALL_PROJECT_LOCATION",
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getListOfLanguagesByUser",
+        return_value="LIST_OF_LANGUAGES_BY_USER",
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getProjectAssessments",
+        return_value="PROJECT_ASSESSMENTS",
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getCountryList",
+        return_value="COUNTRY_LIST",
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getUserProjects",
+        return_value="USER_PROJECTS",
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getActiveProject",
+        return_value="ACTIVE_PROJECT",
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getTheProjectIdForOwner",
+        return_value=1,
+    )
+    @patch("climmob.views.cloneProjects.cloneProjects.projectExists", return_value=True)
+    def test_process_view_clone_project_view_stage_3_error(
+        self,
+        mock_project_exists,
+        mock_get_the_project_id_for_owner,
+        mock_get_active_project,
+        mock_get_user_projects,
+        mock_get_country_list,
+        mock_get_project_assessments,
+        mock_get_list_of_languages_by_user,
+        mock_get_all_project_location,
+        mock_get_all_unit_of_analysis_by_location,
+        mock_get_all_objectives_by_location_and_unit_of_analysis,
+        mock_get_all_affiliations,
+    ):
+        self.view.request.params = {
+            "stage": "3",
+            "project": "CLIMMOB",
+            "user": "test_user",
+        }
+        self.view.request.POST = {
+            "project_cod": "CLIMMOB",
+            "structureToBeCloned": "SOME_VALUE,OTHER_VALUE",
+            "project_location": "CLIMMOB_LOCATION",
+            "project_unit_of_analysis": "5",
+        }
+        result = self.view.processView()
+        self.assertEqual(
+            result,
+            {
+                "activeProject": "ACTIVE_PROJECT",
+                "dataworking": {
+                    "project_cod": "CLIMMOB",
+                    "structureToBeCloned": "SOME_VALUE,OTHER_VALUE",
+                    "project_location": "CLIMMOB_LOCATION",
+                    "project_unit_of_analysis": "5",
+                    "project_numobs": 0,
+                    "project_numcom": 3,
+                    "project_regstatus": 0,
+                    "project_registration_and_analysis": 0,
+                },
+                "projects": "USER_PROJECTS",
+                "countries": "COUNTRY_LIST",
+                "assessments": "PROJECT_ASSESSMENTS",
+                "showForm": False,
+                "error_summary": {},
+                "stage": 3,
+                "listOfLanguages": "LIST_OF_LANGUAGES_BY_USER",
+                "listOfLocations": "ALL_PROJECT_LOCATION",
+                "listOfUnitOfAnalysis": "ALL_UNIT_OF_ANALYSIS_BY_LOCATION",
+                "listOfObjectives": "ALL_OBJECTIVES_BY_LOCATION_AND_UNIT_OF_ANALYSIS",
+                "list_of_affiliation": "AFFILIATION",
+            },
+        )
+        mock_project_exists.assert_called_once_with(
+            self.view.user.login, "test_user", "CLIMMOB", self.view.request
+        )
+        mock_get_the_project_id_for_owner.assert_called_with(
+            "test_user", "CLIMMOB", self.view.request
+        )
+        mock_get_active_project.assert_called_once_with(
+            self.view.user.login, self.view.request
+        )
+        mock_get_user_projects.assert_called_once_with(
+            self.view.user.login, self.view.request
+        )
+        mock_get_country_list.assert_called_once_with(self.view.request)
+        mock_get_project_assessments.assert_called_once_with(1, self.view.request)
+        mock_get_list_of_languages_by_user.assert_called_once_with(
+            self.view.request, self.view.user.login
+        )
+        mock_get_all_project_location.assert_called_once_with(self.view.request)
+        mock_get_all_unit_of_analysis_by_location.assert_called_once_with(
+            self.view.request, "CLIMMOB_LOCATION"
+        )
+        mock_get_all_objectives_by_location_and_unit_of_analysis.assert_called_once_with(
+            self.view.request, "CLIMMOB_LOCATION", "5"
+        )
+        mock_get_all_affiliations.assert_called_once_with(self.view.request)
+
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getTheProjectIdForOwner",
+        return_value=1,
+    )
+    @patch("climmob.views.cloneProjects.cloneProjects.projectExists", return_value=True)
+    def test_process_view_clone_project_view_stage_4_no_data_cloned(
+        self,
+        mock_project_exists,
+        mock_get_the_project_id_for_owner,
+    ):
+        self.view.request.params = {
+            "stage": "4",
+            "project": "CLIMMOB",
+            "user": "test_user",
+        }
+        with self.assertRaises(HTTPNotFound) as context:
+            self.view.processView()
+        self.assertEqual(context.exception.code, 404)
+
+        mock_project_exists.assert_called_once_with(
+            self.view.user.login, "test_user", "CLIMMOB", self.view.request
+        )
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "test_user", "CLIMMOB", self.view.request
+        )
+
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getTheProjectIdForOwner",
+        return_value=1,
+    )
+    @patch("climmob.views.cloneProjects.cloneProjects.projectExists")
+    def test_process_view_clone_project_view_stage_4_no_project_exist(
+        self, mock_project_exists, mock_get_the_project_id_for_owner
+    ):
+        self.view.request.params = {
+            "stage": "4",
+            "project": "CLIMMOB",
+            "user": "test_user",
+            "cloned": "CLIMMOB_CLONED",
+        }
+        mock_project_exists.side_effect = [True, False]
+
+        with self.assertRaises(HTTPNotFound) as context:
+            self.view.processView()
+        self.assertEqual(context.exception.code, 404)
+        mock_project_exists.assert_has_calls(
+            [
+                call(self.view.user.login, "test_user", "CLIMMOB", self.view.request),
+                call(
+                    self.view.user.login,
+                    "test_user",
+                    "CLIMMOB_CLONED",
+                    self.view.request,
+                ),
+            ]
+        )
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "test_user", "CLIMMOB", self.view.request
+        )
+
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getActiveProject",
+        return_value={"data2": "data2"},
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getAllInformationForProject",
+    )
+    @patch("climmob.views.cloneProjects.cloneProjects.getTheProjectIdForOwner")
+    @patch("climmob.views.cloneProjects.cloneProjects.projectExists")
+    def test_process_view_clone_project_view_stage_4_success(
+        self,
+        mock_project_exists,
+        mock_get_the_project_id_for_owner,
+        mock_get_all_information_for_project,
+        mock_get_active_project,
+    ):
+        self.view.request.params = {
+            "stage": "4",
+            "project": "CLIMMOB",
+            "user": "test_user",
+            "cloned": "CLIMMOB_CLONED",
+        }
+        mock_get_all_information_for_project.side_effect = [
+            {"data": "data"},
+            {"data1": "data1"},
+        ]
+        mock_get_the_project_id_for_owner.side_effect = [1, 2]
+        mock_project_exists.side_effect = [True, True]
+
+        result = self.view.processView()
+        self.assertEqual(
+            result,
+            {
+                "activeProject": {"data2": "data2"},
+                "dataworking": {
+                    "structureToBeCloned": "",
+                    "slt_project_by_owner": "test_user___CLIMMOB",
+                    "project_cod": "CLIMMOB_CLONED",
+                    "userInSetion": "test_user",
+                    "clonedProject": {"data": "data"},
+                    "projectBeingCloned": {"data1": "data1"},
+                },
+                "stage": 4,
+            },
+        )
+        mock_project_exists.assert_has_calls(
+            [
+                call("test_user", "test_user", "CLIMMOB", self.view.request),
+                call("test_user", "test_user", "CLIMMOB_CLONED", self.view.request),
+            ]
+        )
+        mock_get_the_project_id_for_owner.assert_has_calls(
+            [
+                call("test_user", "CLIMMOB", self.view.request),
+                call(self.view.user.login, "CLIMMOB_CLONED", self.view.request),
+            ]
+        )
+        mock_get_active_project.assert_called_once_with(
+            self.view.user.login, self.view.request
+        )

--- a/climmob/tests/test_utils/test_views_clone_projects_clone_projects.py
+++ b/climmob/tests/test_utils/test_views_clone_projects_clone_projects.py
@@ -4,7 +4,10 @@ from unittest.mock import patch, MagicMock, ANY, call
 from pyramid.httpexceptions import HTTPNotFound, HTTPFound
 
 from climmob.tests.test_utils.common import BaseViewTestCase
-from climmob.views.cloneProjects.cloneProjects import CloneProjectsView, get_all_information_for_project
+from climmob.views.cloneProjects.cloneProjects import (
+    CloneProjectsView,
+    get_all_information_for_project,
+)
 
 
 class TestModifyProjectView(BaseViewTestCase):
@@ -520,94 +523,197 @@ class TestModifyProjectView(BaseViewTestCase):
             self.view.user.login, self.view.request
         )
 
+
 class TestGetAllInformationForProject(unittest.TestCase):
-
-
-    @patch("climmob.views.cloneProjects.cloneProjects.getProjectAssessments", return_value=[{"ass_cod":1}, {"ass_cod":2}])
-    @patch("climmob.views.cloneProjects.cloneProjects.getDataFormPreview", return_value=({"data":"DATA_7"}, "DATA_8"))
-    @patch("climmob.views.cloneProjects.cloneProjects.getPrjLangDefaultInProject", return_value={"lang_code":"en"})
-    @patch("climmob.views.cloneProjects.cloneProjects.AliasExtraSearchTechnologyInProject")
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getProjectAssessments",
+        return_value=[{"ass_cod": 1}, {"ass_cod": 2}],
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getDataFormPreview",
+        return_value=({"data": "DATA_7"}, "DATA_8"),
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getPrjLangDefaultInProject",
+        return_value={"lang_code": "en"},
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.AliasExtraSearchTechnologyInProject"
+    )
     @patch("climmob.views.cloneProjects.cloneProjects.AliasSearchTechnologyInProject")
     @patch("climmob.views.cloneProjects.cloneProjects.searchTechnologiesInProject")
     @patch("climmob.views.cloneProjects.cloneProjects.getProjectEnumerators")
     @patch("climmob.views.cloneProjects.cloneProjects.getProjectData")
-    def test_get_all_information_for_project_success(self, mock_get_project_data, mock_get_project_enumerators,
-                                             mock_search_technologies_in_project, mock_alias_search_technologies_in_project,
-                                             mock_alias_extra_search_technology_in_project,
-                                             mock_get_proj_lang_default_in_project, mock_get_data_form_preview, mock_get_project_assessments,
-                                             ):
+    def test_get_all_information_for_project_success(
+        self,
+        mock_get_project_data,
+        mock_get_project_enumerators,
+        mock_search_technologies_in_project,
+        mock_alias_search_technologies_in_project,
+        mock_alias_extra_search_technology_in_project,
+        mock_get_proj_lang_default_in_project,
+        mock_get_data_form_preview,
+        mock_get_project_assessments,
+    ):
         userOwner = "test_user"
         projectId = 1
         fake_self = MagicMock()
         fake_self.request = MagicMock()
 
-        mock_get_project_data.return_value = {"project_registration_and_analysis": "DATA"}
+        mock_get_project_data.return_value = {
+            "project_registration_and_analysis": "DATA"
+        }
         mock_get_project_enumerators.return_value = {"project_enumerators": "DATA_1"}
-        mock_search_technologies_in_project.return_value = [{"tech_id":1, "tech1":"TECH1"}, {"tech_id":2, "tech1":"TECH2"}]
+        mock_search_technologies_in_project.return_value = [
+            {"tech_id": 1, "tech1": "TECH1"},
+            {"tech_id": 2, "tech1": "TECH2"},
+        ]
         mock_alias_search_technologies_in_project.side_effect = ["DATA_3", "DATA_4"]
         mock_alias_extra_search_technology_in_project.side_effect = ["DATA_5", "DATA_6"]
 
-
         result = get_all_information_for_project(fake_self, userOwner, projectId)
         self.assertEqual(
-            {'project_registration_and_analysis': 'DATA', 'project_fieldagents': {'project_enumerators': 'DATA_1'},
-             'project_techs': [{'tech_id': 1, 'tech1': 'TECH1', 'alias': 'DATA_3', 'aliasExtra': 'DATA_5'},
-                               {'tech_id': 2, 'tech1': 'TECH2', 'alias': 'DATA_4', 'aliasExtra': 'DATA_6'}],
-             'project_registry': {'data': 'DATA_7'},
-             'project_assessment': [{'ass_cod': 1, 'Questions': {'data': 'DATA_7'}},
-                                    {'ass_cod': 2, 'Questions': {'data': 'DATA_7'}}]}, result)
+            {
+                "project_registration_and_analysis": "DATA",
+                "project_fieldagents": {"project_enumerators": "DATA_1"},
+                "project_techs": [
+                    {
+                        "tech_id": 1,
+                        "tech1": "TECH1",
+                        "alias": "DATA_3",
+                        "aliasExtra": "DATA_5",
+                    },
+                    {
+                        "tech_id": 2,
+                        "tech1": "TECH2",
+                        "alias": "DATA_4",
+                        "aliasExtra": "DATA_6",
+                    },
+                ],
+                "project_registry": {"data": "DATA_7"},
+                "project_assessment": [
+                    {"ass_cod": 1, "Questions": {"data": "DATA_7"}},
+                    {"ass_cod": 2, "Questions": {"data": "DATA_7"}},
+                ],
+            },
+            result,
+        )
         mock_get_project_data.assert_called_once_with(projectId, fake_self.request)
-        mock_get_project_enumerators.assert_called_once_with(projectId, fake_self.request)
-        mock_search_technologies_in_project.assert_called_once_with(projectId, fake_self.request)
-        mock_alias_search_technologies_in_project.assert_called_with(2,projectId, fake_self.request)
-        mock_alias_extra_search_technology_in_project.assert_has_calls([call(1, 1, fake_self.request), call(2, 1, fake_self.request)])
-        mock_get_proj_lang_default_in_project.assert_called_once_with(projectId, fake_self.request)
-        mock_get_data_form_preview.assert_called_with(fake_self, "test_user", 1,assessmentid=2,language="en")
-        mock_get_project_assessments.assert_called_once_with(1,fake_self.request)
+        mock_get_project_enumerators.assert_called_once_with(
+            projectId, fake_self.request
+        )
+        mock_search_technologies_in_project.assert_called_once_with(
+            projectId, fake_self.request
+        )
+        mock_alias_search_technologies_in_project.assert_called_with(
+            2, projectId, fake_self.request
+        )
+        mock_alias_extra_search_technology_in_project.assert_has_calls(
+            [call(1, 1, fake_self.request), call(2, 1, fake_self.request)]
+        )
+        mock_get_proj_lang_default_in_project.assert_called_once_with(
+            projectId, fake_self.request
+        )
+        mock_get_data_form_preview.assert_called_with(
+            fake_self, "test_user", 1, assessmentid=2, language="en"
+        )
+        mock_get_project_assessments.assert_called_once_with(1, fake_self.request)
 
-
-    @patch("climmob.views.cloneProjects.cloneProjects.getProjectAssessments", return_value=[{"ass_cod":1}, {"ass_cod":2}])
-    @patch("climmob.views.cloneProjects.cloneProjects.getDataFormPreview", return_value=({"data":"DATA_7"}, "DATA_8"))
-    @patch("climmob.views.cloneProjects.cloneProjects.getPrjLangDefaultInProject", return_value={})
-    @patch("climmob.views.cloneProjects.cloneProjects.AliasExtraSearchTechnologyInProject")
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getProjectAssessments",
+        return_value=[{"ass_cod": 1}, {"ass_cod": 2}],
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getDataFormPreview",
+        return_value=({"data": "DATA_7"}, "DATA_8"),
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.getPrjLangDefaultInProject",
+        return_value={},
+    )
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.AliasExtraSearchTechnologyInProject"
+    )
     @patch("climmob.views.cloneProjects.cloneProjects.AliasSearchTechnologyInProject")
     @patch("climmob.views.cloneProjects.cloneProjects.searchTechnologiesInProject")
     @patch("climmob.views.cloneProjects.cloneProjects.getProjectEnumerators")
     @patch("climmob.views.cloneProjects.cloneProjects.getProjectData")
-    def test_get_all_information_for_project_success_2(self, mock_get_project_data, mock_get_project_enumerators,
-                                             mock_search_technologies_in_project, mock_alias_search_technologies_in_project,
-                                             mock_alias_extra_search_technology_in_project,
-                                             mock_get_proj_lang_default_in_project, mock_get_data_form_preview, mock_get_project_assessments,
-                                             ):
+    def test_get_all_information_for_project_success_2(
+        self,
+        mock_get_project_data,
+        mock_get_project_enumerators,
+        mock_search_technologies_in_project,
+        mock_alias_search_technologies_in_project,
+        mock_alias_extra_search_technology_in_project,
+        mock_get_proj_lang_default_in_project,
+        mock_get_data_form_preview,
+        mock_get_project_assessments,
+    ):
         userOwner = "test_user"
         projectId = 1
         fake_self = MagicMock()
         fake_self.request = MagicMock()
         fake_self.request.locale_name = "en"
 
-        mock_get_project_data.return_value = {"project_registration_and_analysis": "DATA"}
+        mock_get_project_data.return_value = {
+            "project_registration_and_analysis": "DATA"
+        }
         mock_get_project_enumerators.return_value = {"project_enumerators": "DATA_1"}
-        mock_search_technologies_in_project.return_value = [{"tech_id":1, "tech1":"TECH1"}, {"tech_id":2, "tech1":"TECH2"}]
+        mock_search_technologies_in_project.return_value = [
+            {"tech_id": 1, "tech1": "TECH1"},
+            {"tech_id": 2, "tech1": "TECH2"},
+        ]
         mock_alias_search_technologies_in_project.side_effect = ["DATA_3", "DATA_4"]
         mock_alias_extra_search_technology_in_project.side_effect = ["DATA_5", "DATA_6"]
 
-
         result = get_all_information_for_project(fake_self, userOwner, projectId)
         self.assertEqual(
-            {'project_registration_and_analysis': 'DATA', 'project_fieldagents': {'project_enumerators': 'DATA_1'},
-             'project_techs': [{'tech_id': 1, 'tech1': 'TECH1', 'alias': 'DATA_3', 'aliasExtra': 'DATA_5'},
-                               {'tech_id': 2, 'tech1': 'TECH2', 'alias': 'DATA_4', 'aliasExtra': 'DATA_6'}],
-             'project_registry': {'data': 'DATA_7'},
-             'project_assessment': [{'ass_cod': 1, 'Questions': {'data': 'DATA_7'}},
-                                    {'ass_cod': 2, 'Questions': {'data': 'DATA_7'}}]}, result)
+            {
+                "project_registration_and_analysis": "DATA",
+                "project_fieldagents": {"project_enumerators": "DATA_1"},
+                "project_techs": [
+                    {
+                        "tech_id": 1,
+                        "tech1": "TECH1",
+                        "alias": "DATA_3",
+                        "aliasExtra": "DATA_5",
+                    },
+                    {
+                        "tech_id": 2,
+                        "tech1": "TECH2",
+                        "alias": "DATA_4",
+                        "aliasExtra": "DATA_6",
+                    },
+                ],
+                "project_registry": {"data": "DATA_7"},
+                "project_assessment": [
+                    {"ass_cod": 1, "Questions": {"data": "DATA_7"}},
+                    {"ass_cod": 2, "Questions": {"data": "DATA_7"}},
+                ],
+            },
+            result,
+        )
         mock_get_project_data.assert_called_once_with(projectId, fake_self.request)
-        mock_get_project_enumerators.assert_called_once_with(projectId, fake_self.request)
-        mock_search_technologies_in_project.assert_called_once_with(projectId, fake_self.request)
-        mock_alias_search_technologies_in_project.assert_called_with(2,projectId, fake_self.request)
-        mock_alias_extra_search_technology_in_project.assert_has_calls([call(1, 1, fake_self.request), call(2, 1, fake_self.request)])
-        mock_get_proj_lang_default_in_project.assert_called_once_with(projectId, fake_self.request)
-        mock_get_data_form_preview.assert_called_with(fake_self, "test_user", 1,assessmentid=2,language="en")
-        mock_get_project_assessments.assert_called_once_with(1,fake_self.request)
+        mock_get_project_enumerators.assert_called_once_with(
+            projectId, fake_self.request
+        )
+        mock_search_technologies_in_project.assert_called_once_with(
+            projectId, fake_self.request
+        )
+        mock_alias_search_technologies_in_project.assert_called_with(
+            2, projectId, fake_self.request
+        )
+        mock_alias_extra_search_technology_in_project.assert_has_calls(
+            [call(1, 1, fake_self.request), call(2, 1, fake_self.request)]
+        )
+        mock_get_proj_lang_default_in_project.assert_called_once_with(
+            projectId, fake_self.request
+        )
+        mock_get_data_form_preview.assert_called_with(
+            fake_self, "test_user", 1, assessmentid=2, language="en"
+        )
+        mock_get_project_assessments.assert_called_once_with(1, fake_self.request)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/climmob/tests/test_utils/test_views_clone_projects_clone_projects.py
+++ b/climmob/tests/test_utils/test_views_clone_projects_clone_projects.py
@@ -1,10 +1,10 @@
+import unittest
 from unittest.mock import patch, MagicMock, ANY, call
 
-from fontTools.misc.cython import returns
 from pyramid.httpexceptions import HTTPNotFound, HTTPFound
 
 from climmob.tests.test_utils.common import BaseViewTestCase
-from climmob.views.cloneProjects.cloneProjects import CloneProjectsView
+from climmob.views.cloneProjects.cloneProjects import CloneProjectsView, get_all_information_for_project
 
 
 class TestModifyProjectView(BaseViewTestCase):
@@ -54,6 +54,53 @@ class TestModifyProjectView(BaseViewTestCase):
         with self.assertRaises(HTTPNotFound) as context:
             self.view.processView()
             self.assertEqual(context.exception.code, 404)
+        mock_project_exists.assert_called_once_with(
+            self.view.user.login, "test_user", "CLIMMOB", self.view.request
+        )
+
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.projectExists", return_value=False
+    )
+    def test_process_view_clone_project_view_no_stage_success(
+        self, mock_project_exists
+    ):
+        self.view.request.params = {
+            "project": "CLIMMOB",
+            "user": "test_user",
+        }
+        self.view.request.POST = {"slt_project_by_owner": "test_user___CLIMMOB"}
+        self.view.request.route_url = MagicMock(
+            return_value="/cloneProject?stage=2&project=my_project&user=test_user"
+        )
+        result = self.view.processView()
+        self.assertIsInstance(result, HTTPFound)
+        self.assertEqual(
+            result.location, "/cloneProject?stage=2&project=my_project&user=test_user"
+        )
+        mock_project_exists.assert_called_once_with(
+            self.view.user.login, "test_user", "CLIMMOB", self.view.request
+        )
+
+    @patch(
+        "climmob.views.cloneProjects.cloneProjects.projectExists", return_value=False
+    )
+    def test_process_view_clone_project_view_stage_error_success(
+        self, mock_project_exists
+    ):
+        self.view.request.params = {
+            "stage": "a",
+            "project": "CLIMMOB",
+            "user": "test_user",
+        }
+        self.view.request.POST = {"slt_project_by_owner": "test_user___CLIMMOB"}
+        self.view.request.route_url = MagicMock(
+            return_value="/cloneProject?stage=2&project=my_project&user=test_user"
+        )
+        result = self.view.processView()
+        self.assertIsInstance(result, HTTPFound)
+        self.assertEqual(
+            result.location, "/cloneProject?stage=2&project=my_project&user=test_user"
+        )
         mock_project_exists.assert_called_once_with(
             self.view.user.login, "test_user", "CLIMMOB", self.view.request
         )
@@ -130,7 +177,7 @@ class TestModifyProjectView(BaseViewTestCase):
     )
     @patch("climmob.views.cloneProjects.cloneProjects.getActiveProject", return_value=1)
     @patch(
-        "climmob.views.cloneProjects.cloneProjects.getAllInformationForProject",
+        "climmob.views.cloneProjects.cloneProjects.get_all_information_for_project",
         return_value={"data": "data"},
     )
     @patch(
@@ -417,7 +464,7 @@ class TestModifyProjectView(BaseViewTestCase):
         return_value={"data2": "data2"},
     )
     @patch(
-        "climmob.views.cloneProjects.cloneProjects.getAllInformationForProject",
+        "climmob.views.cloneProjects.cloneProjects.get_all_information_for_project",
     )
     @patch("climmob.views.cloneProjects.cloneProjects.getTheProjectIdForOwner")
     @patch("climmob.views.cloneProjects.cloneProjects.projectExists")
@@ -472,3 +519,95 @@ class TestModifyProjectView(BaseViewTestCase):
         mock_get_active_project.assert_called_once_with(
             self.view.user.login, self.view.request
         )
+
+class TestGetAllInformationForProject(unittest.TestCase):
+
+
+    @patch("climmob.views.cloneProjects.cloneProjects.getProjectAssessments", return_value=[{"ass_cod":1}, {"ass_cod":2}])
+    @patch("climmob.views.cloneProjects.cloneProjects.getDataFormPreview", return_value=({"data":"DATA_7"}, "DATA_8"))
+    @patch("climmob.views.cloneProjects.cloneProjects.getPrjLangDefaultInProject", return_value={"lang_code":"en"})
+    @patch("climmob.views.cloneProjects.cloneProjects.AliasExtraSearchTechnologyInProject")
+    @patch("climmob.views.cloneProjects.cloneProjects.AliasSearchTechnologyInProject")
+    @patch("climmob.views.cloneProjects.cloneProjects.searchTechnologiesInProject")
+    @patch("climmob.views.cloneProjects.cloneProjects.getProjectEnumerators")
+    @patch("climmob.views.cloneProjects.cloneProjects.getProjectData")
+    def test_get_all_information_for_project_success(self, mock_get_project_data, mock_get_project_enumerators,
+                                             mock_search_technologies_in_project, mock_alias_search_technologies_in_project,
+                                             mock_alias_extra_search_technology_in_project,
+                                             mock_get_proj_lang_default_in_project, mock_get_data_form_preview, mock_get_project_assessments,
+                                             ):
+        userOwner = "test_user"
+        projectId = 1
+        fake_self = MagicMock()
+        fake_self.request = MagicMock()
+
+        mock_get_project_data.return_value = {"project_registration_and_analysis": "DATA"}
+        mock_get_project_enumerators.return_value = {"project_enumerators": "DATA_1"}
+        mock_search_technologies_in_project.return_value = [{"tech_id":1, "tech1":"TECH1"}, {"tech_id":2, "tech1":"TECH2"}]
+        mock_alias_search_technologies_in_project.side_effect = ["DATA_3", "DATA_4"]
+        mock_alias_extra_search_technology_in_project.side_effect = ["DATA_5", "DATA_6"]
+
+
+        result = get_all_information_for_project(fake_self, userOwner, projectId)
+        self.assertEqual(
+            {'project_registration_and_analysis': 'DATA', 'project_fieldagents': {'project_enumerators': 'DATA_1'},
+             'project_techs': [{'tech_id': 1, 'tech1': 'TECH1', 'alias': 'DATA_3', 'aliasExtra': 'DATA_5'},
+                               {'tech_id': 2, 'tech1': 'TECH2', 'alias': 'DATA_4', 'aliasExtra': 'DATA_6'}],
+             'project_registry': {'data': 'DATA_7'},
+             'project_assessment': [{'ass_cod': 1, 'Questions': {'data': 'DATA_7'}},
+                                    {'ass_cod': 2, 'Questions': {'data': 'DATA_7'}}]}, result)
+        mock_get_project_data.assert_called_once_with(projectId, fake_self.request)
+        mock_get_project_enumerators.assert_called_once_with(projectId, fake_self.request)
+        mock_search_technologies_in_project.assert_called_once_with(projectId, fake_self.request)
+        mock_alias_search_technologies_in_project.assert_called_with(2,projectId, fake_self.request)
+        mock_alias_extra_search_technology_in_project.assert_has_calls([call(1, 1, fake_self.request), call(2, 1, fake_self.request)])
+        mock_get_proj_lang_default_in_project.assert_called_once_with(projectId, fake_self.request)
+        mock_get_data_form_preview.assert_called_with(fake_self, "test_user", 1,assessmentid=2,language="en")
+        mock_get_project_assessments.assert_called_once_with(1,fake_self.request)
+
+
+    @patch("climmob.views.cloneProjects.cloneProjects.getProjectAssessments", return_value=[{"ass_cod":1}, {"ass_cod":2}])
+    @patch("climmob.views.cloneProjects.cloneProjects.getDataFormPreview", return_value=({"data":"DATA_7"}, "DATA_8"))
+    @patch("climmob.views.cloneProjects.cloneProjects.getPrjLangDefaultInProject", return_value={})
+    @patch("climmob.views.cloneProjects.cloneProjects.AliasExtraSearchTechnologyInProject")
+    @patch("climmob.views.cloneProjects.cloneProjects.AliasSearchTechnologyInProject")
+    @patch("climmob.views.cloneProjects.cloneProjects.searchTechnologiesInProject")
+    @patch("climmob.views.cloneProjects.cloneProjects.getProjectEnumerators")
+    @patch("climmob.views.cloneProjects.cloneProjects.getProjectData")
+    def test_get_all_information_for_project_success_2(self, mock_get_project_data, mock_get_project_enumerators,
+                                             mock_search_technologies_in_project, mock_alias_search_technologies_in_project,
+                                             mock_alias_extra_search_technology_in_project,
+                                             mock_get_proj_lang_default_in_project, mock_get_data_form_preview, mock_get_project_assessments,
+                                             ):
+        userOwner = "test_user"
+        projectId = 1
+        fake_self = MagicMock()
+        fake_self.request = MagicMock()
+        fake_self.request.locale_name = "en"
+
+        mock_get_project_data.return_value = {"project_registration_and_analysis": "DATA"}
+        mock_get_project_enumerators.return_value = {"project_enumerators": "DATA_1"}
+        mock_search_technologies_in_project.return_value = [{"tech_id":1, "tech1":"TECH1"}, {"tech_id":2, "tech1":"TECH2"}]
+        mock_alias_search_technologies_in_project.side_effect = ["DATA_3", "DATA_4"]
+        mock_alias_extra_search_technology_in_project.side_effect = ["DATA_5", "DATA_6"]
+
+
+        result = get_all_information_for_project(fake_self, userOwner, projectId)
+        self.assertEqual(
+            {'project_registration_and_analysis': 'DATA', 'project_fieldagents': {'project_enumerators': 'DATA_1'},
+             'project_techs': [{'tech_id': 1, 'tech1': 'TECH1', 'alias': 'DATA_3', 'aliasExtra': 'DATA_5'},
+                               {'tech_id': 2, 'tech1': 'TECH2', 'alias': 'DATA_4', 'aliasExtra': 'DATA_6'}],
+             'project_registry': {'data': 'DATA_7'},
+             'project_assessment': [{'ass_cod': 1, 'Questions': {'data': 'DATA_7'}},
+                                    {'ass_cod': 2, 'Questions': {'data': 'DATA_7'}}]}, result)
+        mock_get_project_data.assert_called_once_with(projectId, fake_self.request)
+        mock_get_project_enumerators.assert_called_once_with(projectId, fake_self.request)
+        mock_search_technologies_in_project.assert_called_once_with(projectId, fake_self.request)
+        mock_alias_search_technologies_in_project.assert_called_with(2,projectId, fake_self.request)
+        mock_alias_extra_search_technology_in_project.assert_has_calls([call(1, 1, fake_self.request), call(2, 1, fake_self.request)])
+        mock_get_proj_lang_default_in_project.assert_called_once_with(projectId, fake_self.request)
+        mock_get_data_form_preview.assert_called_with(fake_self, "test_user", 1,assessmentid=2,language="en")
+        mock_get_project_assessments.assert_called_once_with(1,fake_self.request)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/climmob/tests/test_utils/test_views_project.py
+++ b/climmob/tests/test_utils/test_views_project.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock, patch, ANY
+from unittest.mock import MagicMock, patch, ANY, call
 
 from pyramid.httpexceptions import HTTPNotFound, HTTPFound
 
@@ -9,6 +9,9 @@ from climmob.views.project import (
     GetObjectivesByLocationAndUnitOfAnalysisView,
     NewProjectView,
     ModifyProjectView,
+    GetTemplatesByTypeOfProjectView,
+    ProjectListView,
+    DeleteProjectView,
 )
 
 
@@ -235,9 +238,10 @@ class TestNewProjectView(BaseViewTestCase):
         )
         mock_get_all_affiliations.assert_called_once_with(self.view.request)
 
+    @patch("climmob.views.project.p.PluginImplementations")
     @patch("climmob.views.project.create_project_function")
     def test_process_view_new_project_view_post_success(
-        self, mock_create_project_function
+        self, mock_create_project_function, mock_p_plugin_implementations
     ):
         self.view.request.POST = {
             "submit": "1",
@@ -253,10 +257,20 @@ class TestNewProjectView(BaseViewTestCase):
             {},
             True,
         )
+        plugin_mock1 = MagicMock()
+        plugin_mock2 = MagicMock()
+        mock_p_plugin_implementations.return_value = [plugin_mock1, plugin_mock2]
+
         self.view.user.fullName = "SOME_VALUE"
         self.view.user.email = "CLIMMOB@EXAMPLE.COM"
         result = self.view.processView()
         self.assertIsInstance(result, HTTPFound)
+        plugin_mock1.after_adding_project.assert_called_once_with(
+            self.view.request, "test_user", {"project_cod": "VALUE123"}
+        )
+        plugin_mock2.after_adding_project.assert_called_once_with(
+            self.view.request, "test_user", {"project_cod": "VALUE123"}
+        )
 
 
 class TestModifyProjectView(BaseViewTestCase):
@@ -304,7 +318,7 @@ class TestModifyProjectView(BaseViewTestCase):
     @patch("climmob.views.project.get_location_unit_of_analysis_by_combination")
     @patch("climmob.views.project.getProjectData")
     @patch("climmob.views.project.getTheProjectIdForOwner", return_value=1)
-    def test_processView_success(
+    def test_process_view_modify_project_view_success(
         self,
         mock_get_the_project_id_for_owner,
         mock_get_project_data,
@@ -320,12 +334,8 @@ class TestModifyProjectView(BaseViewTestCase):
         mock_get_project_assessments,
         mock_function_create_clone,
     ):
-
         mock_plugin = MagicMock()
         mock_plugin.before_updating_project.return_value = (True, "", "data")
-
-        mock_plugin.before_updating_project.return_value = (True, "", "data")
-
         self.view.request.POST = {
             "btn_addNewProject": "1",
             "project_cod": "VALUE123",
@@ -344,7 +354,6 @@ class TestModifyProjectView(BaseViewTestCase):
             "project_languages": ["en", "es"],
             "project_objectives": ["obj1"],
         }
-
         mock_get_project_data.return_value = {
             "project_localvariety": 1,
             "project_regstatus": 0,
@@ -356,7 +365,6 @@ class TestModifyProjectView(BaseViewTestCase):
             "project_objectives": ["obj1"],
             "project_languages": ["en"],
         }
-
         self.view.getPostDict = MagicMock(
             return_value={
                 "project_cod": "VALUE123",
@@ -395,12 +403,12 @@ class TestModifyProjectView(BaseViewTestCase):
         mock_get_the_project_id_for_owner.assert_called_with(
             self.view.user.login, "testproject", self.view.request
         )
-        assert mock_get_project_data.call_count >= 2
-
+        mock_get_project_data.asssert_has_calls(
+            [call(1, self.view.request), call(1, self.view.request)]
+        )
         mock_get_location_unit_of_analysis_by_combination.assert_called_once_with(
             self.view.request, "CLIMMOB", "1"
         )
-
         mock_modify_project.assert_called_once()
         mock_modify_project.assert_called_with(1, ANY, self.view.request)
         mock_delete_all_project_location_unit_objective.assert_called_once_with(
@@ -414,6 +422,1186 @@ class TestModifyProjectView(BaseViewTestCase):
         mock_delete_project_assessments.assert_called()
         mock_get_project_assessments.assert_called()
         mock_function_create_clone.assert_called_once()
+
+    @patch("climmob.views.project.p.PluginImplementations")
+    @patch(
+        "climmob.views.project.get_all_affiliations",
+        return_value={"DATA_ALL_AFFILIATIONS": "DATA_7"},
+    )
+    @patch(
+        "climmob.views.project.get_all_objectives_by_location_and_unit_of_analysis",
+        return_value={"DATA_ALL_OBJECT_&_UNIT_OF_ANA": "DATA_6"},
+    )
+    @patch(
+        "climmob.views.project.get_all_unit_of_analysis_by_location",
+        return_value={"DATA_ALL_UNIT_ANA_LOC": "DATA_5"},
+    )
+    @patch(
+        "climmob.views.project.get_all_project_location",
+        return_value={"DATA_ALL_PROJECT_LOC": "DATA_5"},
+    )
+    @patch(
+        "climmob.views.project.getListOfLanguagesByUser",
+        return_value={"DATA_LIST_LANG_BT_USER": {"DATA_4_A", "DATA_4_B"}},
+    )
+    @patch(
+        "climmob.views.project.getProjectTemplates",
+        return_value={"DATA_TEMPLATES": "DATA_3"},
+    )
+    @patch(
+        "climmob.views.project.getCountryList", return_value=["DATA_2_A", "DATA_2_B"]
+    )
+    @patch(
+        "climmob.views.project.getActiveProject",
+        return_value={"DATA_ACTIVE_PROJECT": "DATA_1"},
+    )
+    @patch("climmob.views.project.getProjectData")
+    @patch("climmob.views.project.getTheProjectIdForOwner", return_value=1)
+    def test_process_view_modify_project_view_proj_no_comply_limitation(
+        self,
+        mock_get_the_project_id_for_owner,
+        mock_get_project_data,
+        mock_get_active_project,
+        mock_get_country_list,
+        mock_get_project_templates,
+        mock_get_list_of_languages_by_user,
+        mock_get_all_project_location,
+        mock_get_all_unit_of_analysis_by_location,
+        mock_get_all_objectives_by_location_and_unit_of_analysis,
+        mock_get_all_affiliations,
+        mock_plugin_implementations,
+    ):
+        mock_get_project_data.return_value = {
+            "project_regstatus": 0,
+            "project_numobs": 300,
+            "project_numcom": 2,
+            "project_registration_and_analysis": 1,
+            "project_template_used": "",
+            "project_cod": "VALUE123",
+            "project_objectives": ["obj1"],
+            "project_languages": ["en"],
+            "project_localvariety": "2",
+        }
+        self.view.request.POST = {
+            "btn_addNewProject": "1",
+            "project_cod": "VALUE123",
+            "project_registration_and_analysis": "1",
+            "project_location": "CLIMMOB",
+            "project_unit_of_analysis": "1",
+            "project_label_a": "PROJECT_LABEL_A",
+            "project_label_b": "PROJECT_LABEL_B",
+            "project_label_c": "PROJECT_LABEL_C",
+            "project_numobs": "300",
+            "project_numcom": "20",
+            "project_type": "off",
+            "usingTemplate": "template1",
+            "project_languages": ["en", "es"],
+            "project_objectives": ["obj1"],
+        }
+        self.view.request.registry.settings = {
+            "projects.limit": "true",
+            "project.maximumnumberofobservations": "100",
+        }
+        plugin1 = MagicMock()
+        plugin2 = MagicMock()
+
+        plugin1.before_returning_project_context.side_effect = lambda req, ctx: {
+            **ctx,
+            "plugin1": True,
+        }
+        plugin2.before_returning_project_context.side_effect = lambda req, ctx: {
+            **ctx,
+            "plugin2": "ok",
+        }
+        mock_plugin_implementations.return_value = [plugin1, plugin2]
+
+        self.view._ = MagicMock(
+            return_value="This project does not comply with the limitations on the number of participants per project."
+        )
+
+        result = self.view.processView()
+
+        self.assertEqual(
+            result,
+            {
+                "activeProject": {"DATA_ACTIVE_PROJECT": "DATA_1"},
+                "indashboard": True,
+                "data": {
+                    "btn_addNewProject": "1",
+                    "project_cod": "testproject",
+                    "project_registration_and_analysis": "1",
+                    "project_location": "CLIMMOB",
+                    "project_unit_of_analysis": "1",
+                    "project_label_a": "PROJECT_LABEL_A",
+                    "project_label_b": "PROJECT_LABEL_B",
+                    "project_label_c": "PROJECT_LABEL_C",
+                    "project_numobs": "300",
+                    "project_numcom": "20",
+                    "project_type": 1,
+                    "usingTemplate": "template1",
+                    "project_languages": ["en", "es"],
+                    "project_objectives": ["obj1"],
+                    "project_template": 0,
+                    "project_regstatus": 0,
+                },
+                "newproject": False,
+                "countries": ["DATA_2_A", "DATA_2_B"],
+                "error_summary": {
+                    "projectslimits": "This project does not comply with the limitations on the number of participants per project."
+                },
+                "listOfTemplates": {"DATA_TEMPLATES": "DATA_3"},
+                "listOfLanguages": {"DATA_LIST_LANG_BT_USER": {"DATA_4_B", "DATA_4_A"}},
+                "listOfLocations": {"DATA_ALL_PROJECT_LOC": "DATA_5"},
+                "listOfUnitOfAnalysis": {"DATA_ALL_UNIT_ANA_LOC": "DATA_5"},
+                "listOfObjectives": {"DATA_ALL_OBJECT_&_UNIT_OF_ANA": "DATA_6"},
+                "list_of_affiliation": {"DATA_ALL_AFFILIATIONS": "DATA_7"},
+                "plugin1": True,
+                "plugin2": "ok",
+            },
+        )
+        plugin1.before_returning_project_context.assert_called_once_with(
+            self.view.request,
+            {
+                "activeProject": {"DATA_ACTIVE_PROJECT": "DATA_1"},
+                "indashboard": True,
+                "data": {
+                    "btn_addNewProject": "1",
+                    "project_cod": "testproject",
+                    "project_registration_and_analysis": "1",
+                    "project_location": "CLIMMOB",
+                    "project_unit_of_analysis": "1",
+                    "project_label_a": "PROJECT_LABEL_A",
+                    "project_label_b": "PROJECT_LABEL_B",
+                    "project_label_c": "PROJECT_LABEL_C",
+                    "project_numobs": "300",
+                    "project_numcom": "20",
+                    "project_type": 1,
+                    "usingTemplate": "template1",
+                    "project_languages": ["en", "es"],
+                    "project_objectives": ["obj1"],
+                    "project_template": 0,
+                    "project_regstatus": 0,
+                },
+                "newproject": False,
+                "countries": ["DATA_2_A", "DATA_2_B"],
+                "error_summary": {
+                    "projectslimits": "This project does not comply with the limitations on the number of participants per project."
+                },
+                "listOfTemplates": {"DATA_TEMPLATES": "DATA_3"},
+                "listOfLanguages": {"DATA_LIST_LANG_BT_USER": {"DATA_4_B", "DATA_4_A"}},
+                "listOfLocations": {"DATA_ALL_PROJECT_LOC": "DATA_5"},
+                "listOfUnitOfAnalysis": {"DATA_ALL_UNIT_ANA_LOC": "DATA_5"},
+                "listOfObjectives": {"DATA_ALL_OBJECT_&_UNIT_OF_ANA": "DATA_6"},
+                "list_of_affiliation": {"DATA_ALL_AFFILIATIONS": "DATA_7"},
+            },
+        )
+        mock_get_the_project_id_for_owner.assert_called_with(
+            self.view.user.login, "testproject", self.view.request
+        )
+        mock_get_project_data.asssert_has_calls(
+            [call(1, self.view.request), call(1, self.view.request)]
+        )
+        mock_get_active_project.assert_called_once_with("testuser", self.view.request)
+        mock_get_country_list.assert_called_once_with(self.view.request)
+        mock_get_project_templates.assert_called_once_with(self.view.request, "1")
+        mock_get_list_of_languages_by_user.assert_called_once_with(
+            self.view.request, "testuser"
+        )
+        mock_get_all_project_location.assert_called_once_with(self.view.request)
+        mock_get_all_unit_of_analysis_by_location.assert_called_once_with(
+            self.view.request, "CLIMMOB"
+        )
+        mock_get_all_objectives_by_location_and_unit_of_analysis.assert_called_once_with(
+            self.view.request, "CLIMMOB", "1"
+        )
+        mock_get_all_affiliations.assert_called_once_with(self.view.request)
+
+    @patch("climmob.views.project.p.PluginImplementations")
+    @patch(
+        "climmob.views.project.get_all_affiliations",
+        return_value={"DATA_ALL_AFFILIATIONS": "DATA_7"},
+    )
+    @patch(
+        "climmob.views.project.get_all_objectives_by_location_and_unit_of_analysis",
+        return_value={"DATA_ALL_OBJECT_&_UNIT_OF_ANA": "DATA_6"},
+    )
+    @patch(
+        "climmob.views.project.get_all_unit_of_analysis_by_location",
+        return_value={"DATA_ALL_UNIT_ANA_LOC": "DATA_5"},
+    )
+    @patch(
+        "climmob.views.project.get_all_project_location",
+        return_value={"DATA_ALL_PROJECT_LOC": "DATA_5"},
+    )
+    @patch(
+        "climmob.views.project.getListOfLanguagesByUser",
+        return_value={"DATA_LIST_LANG_BT_USER": {"DATA_4_A", "DATA_4_B"}},
+    )
+    @patch(
+        "climmob.views.project.getProjectTemplates",
+        return_value={"DATA_TEMPLATES": "DATA_3"},
+    )
+    @patch(
+        "climmob.views.project.getCountryList", return_value=["DATA_2_A", "DATA_2_B"]
+    )
+    @patch(
+        "climmob.views.project.getActiveProject",
+        return_value={"DATA_ACTIVE_PROJECT": "DATA_1"},
+    )
+    @patch(
+        "climmob.views.project.modifyProject", return_value=(False, "Error to modify")
+    )
+    @patch("climmob.views.project.get_location_unit_of_analysis_by_combination")
+    @patch("climmob.views.project.getProjectData")
+    @patch("climmob.views.project.getTheProjectIdForOwner", return_value=1)
+    def test_process_view_modify_project_view_proj_error_to_modify(
+        self,
+        mock_get_the_project_id_for_owner,
+        mock_get_project_data,
+        mock_get_location_unit_of_analysis_by_combination,
+        mock_modify_project,
+        mock_get_active_project,
+        mock_get_country_list,
+        mock_get_project_templates,
+        mock_get_list_of_languages_by_user,
+        mock_get_all_project_location,
+        mock_get_all_unit_of_analysis_by_location,
+        mock_get_all_objectives_by_location_and_unit_of_analysis,
+        mock_get_all_affiliations,
+        mock_plugin_implementations,
+    ):
+        mock_get_project_data.return_value = {
+            "project_regstatus": 1,
+            "project_numobs": 300,
+            "project_numcom": 2,
+            "project_registration_and_analysis": 1,
+            "project_template_used": "",
+            "project_cod": "VALUE123",
+            "project_objectives": ["obj1"],
+            "project_languages": ["en"],
+            "project_localvariety": 1,
+        }
+        self.view.request.POST = {
+            "btn_addNewProject": "1",
+            "project_cod": "VALUE123",
+            "project_registration_and_analysis": "1",
+            "project_location": "CLIMMOB",
+            "project_unit_of_analysis": "1",
+            "project_label_a": "PROJECT_LABEL_A",
+            "project_label_b": "PROJECT_LABEL_B",
+            "project_label_c": "PROJECT_LABEL_C",
+            "project_numobs": "30",
+            "project_numcom": "20",
+            "project_type": "off",
+            "usingTemplate": "template1",
+            "project_languages": ["en", "es"],
+            "project_objectives": ["obj1"],
+            "project_template": "off",
+            "project_localvariety": "1",
+        }
+        self.view.request.registry.settings = {
+            "projects.limit": "true",
+            "project.maximumnumberofobservations": "100",
+        }
+        plugin1 = MagicMock()
+        plugin2 = MagicMock()
+
+        plugin1.before_returning_project_context.side_effect = lambda req, ctx: {
+            **ctx,
+            "plugin1": True,
+        }
+        plugin2.before_returning_project_context.side_effect = lambda req, ctx: {
+            **ctx,
+            "plugin2": "ok",
+        }
+        mock_plugin_implementations.return_value = [plugin1, plugin2]
+        plugin1.before_updating_project.return_value = (
+            True,
+            "",
+            {
+                "project_localvariety": "0",
+                "project_cod": "VALUE123",
+                "project_registration_and_analysis": "1",
+                "project_languages": ["en", "es"],
+                "project_objectives": ["obj1"],
+                "project_location": "CLIMMOB",
+                "project_unit_of_analysis": "1",
+            },
+        )
+        plugin2.before_updating_project.return_value = (
+            True,
+            "",
+            {
+                "project_localvariety": "0",
+                "project_cod": "VALUE123",
+                "project_registration_and_analysis": "1",
+                "project_languages": ["en", "es"],
+                "project_objectives": ["obj1"],
+                "project_location": "CLIMMOB",
+                "project_unit_of_analysis": "1",
+            },
+        )
+        self.view._ = MagicMock(
+            return_value="This project does not comply with the limitations on the number of participants per project."
+        )
+
+        mock_get_location_unit_of_analysis_by_combination.return_value = {
+            "pluoa_id": 2,
+            "plocation_id": 1,
+            "puoa_id": 2,
+            "registration_and_analysis": 1,
+        }
+        result = self.view.processView()
+        self.assertEqual(
+            result,
+            {
+                "activeProject": {"DATA_ACTIVE_PROJECT": "DATA_1"},
+                "indashboard": True,
+                "data": {
+                    "project_localvariety": "off",
+                    "project_cod": "VALUE123",
+                    "project_registration_and_analysis": 1,
+                    "project_languages": ["en", "es"],
+                    "project_objectives": ["obj1"],
+                    "project_location": "CLIMMOB",
+                    "project_unit_of_analysis": "1",
+                },
+                "newproject": False,
+                "countries": ["DATA_2_A", "DATA_2_B"],
+                "error_summary": {"dberror": "Error to modify"},
+                "listOfTemplates": {"DATA_TEMPLATES": "DATA_3"},
+                "listOfLanguages": {"DATA_LIST_LANG_BT_USER": {"DATA_4_B", "DATA_4_A"}},
+                "listOfLocations": {"DATA_ALL_PROJECT_LOC": "DATA_5"},
+                "listOfUnitOfAnalysis": {"DATA_ALL_UNIT_ANA_LOC": "DATA_5"},
+                "listOfObjectives": {"DATA_ALL_OBJECT_&_UNIT_OF_ANA": "DATA_6"},
+                "list_of_affiliation": {"DATA_ALL_AFFILIATIONS": "DATA_7"},
+                "plugin1": True,
+                "plugin2": "ok",
+            },
+        )
+        mock_get_the_project_id_for_owner.assert_called_with(
+            self.view.user.login, "testproject", self.view.request
+        )
+        mock_get_project_data.asssert_has_calls(
+            [call(1, self.view.request), call(1, self.view.request)]
+        )
+        mock_get_location_unit_of_analysis_by_combination.assert_called_once_with(
+            self.view.request, "CLIMMOB", "1"
+        )
+        mock_modify_project.assert_called_once_with(
+            1,
+            {
+                "project_localvariety": "off",
+                "project_cod": "VALUE123",
+                "project_registration_and_analysis": 1,
+                "project_languages": ["en", "es"],
+                "project_objectives": ["obj1"],
+                "project_location": "CLIMMOB",
+                "project_unit_of_analysis": "1",
+            },
+            self.view.request,
+        )
+        mock_get_active_project.assert_called_once_with("testuser", self.view.request)
+        mock_get_country_list.assert_called_once_with(self.view.request)
+        mock_get_project_templates.assert_called_once_with(self.view.request, 1)
+        mock_get_list_of_languages_by_user.assert_called_once_with(
+            self.view.request, "testuser"
+        )
+        mock_get_all_project_location.assert_called_once_with(self.view.request)
+        mock_get_all_unit_of_analysis_by_location.assert_called_once_with(
+            self.view.request, "CLIMMOB"
+        )
+        mock_get_all_objectives_by_location_and_unit_of_analysis.assert_called_once_with(
+            self.view.request, "CLIMMOB", "1"
+        )
+        mock_get_all_affiliations.assert_called_once_with(self.view.request)
+
+    @patch("climmob.views.project.p.PluginImplementations")
+    @patch(
+        "climmob.views.project.get_all_affiliations",
+        return_value={"DATA_ALL_AFFILIATIONS": "DATA_7"},
+    )
+    @patch(
+        "climmob.views.project.get_all_objectives_by_location_and_unit_of_analysis",
+        return_value={"DATA_ALL_OBJECT_&_UNIT_OF_ANA": "DATA_6"},
+    )
+    @patch(
+        "climmob.views.project.get_all_unit_of_analysis_by_location",
+        return_value={"DATA_ALL_UNIT_ANA_LOC": "DATA_5"},
+    )
+    @patch(
+        "climmob.views.project.get_all_project_location",
+        return_value={"DATA_ALL_PROJECT_LOC": "DATA_5"},
+    )
+    @patch(
+        "climmob.views.project.getListOfLanguagesByUser",
+        return_value={"DATA_LIST_LANG_BT_USER": {"DATA_4_A", "DATA_4_B"}},
+    )
+    @patch(
+        "climmob.views.project.getProjectTemplates",
+        return_value={"DATA_TEMPLATES": "DATA_3"},
+    )
+    @patch(
+        "climmob.views.project.getCountryList", return_value=["DATA_2_A", "DATA_2_B"]
+    )
+    @patch(
+        "climmob.views.project.getActiveProject",
+        return_value={"DATA_ACTIVE_PROJECT": "DATA_1"},
+    )
+    @patch("climmob.views.project.getProjectData")
+    @patch("climmob.views.project.getTheProjectIdForOwner", return_value=1)
+    def test_process_view_modify_project_view_proj_same_question(
+        self,
+        mock_get_the_project_id_for_owner,
+        mock_get_project_data,
+        mock_get_active_project,
+        mock_get_country_list,
+        mock_get_project_templates,
+        mock_get_list_of_languages_by_user,
+        mock_get_all_project_location,
+        mock_get_all_unit_of_analysis_by_location,
+        mock_get_all_objectives_by_location_and_unit_of_analysis,
+        mock_get_all_affiliations,
+        mock_plugin_implementations,
+    ):
+        mock_get_project_data.return_value = {
+            "project_regstatus": 1,
+            "project_numobs": 300,
+            "project_numcom": 2,
+            "project_registration_and_analysis": 1,
+            "project_template_used": "",
+            "project_cod": "VALUE123",
+            "project_objectives": ["obj1"],
+            "project_languages": ["en"],
+            "project_localvariety": 1,
+        }
+        self.view.request.POST = {
+            "btn_addNewProject": "1",
+            "project_cod": "VALUE123",
+            "project_registration_and_analysis": "1",
+            "project_location": "CLIMMOB",
+            "project_unit_of_analysis": "1",
+            "project_label_a": "PROJECT_LABEL",
+            "project_label_b": "PROJECT_LABEL",
+            "project_label_c": "PROJECT_LABEL",
+            "project_numobs": "30",
+            "project_numcom": "20",
+            "project_type": "off",
+            "usingTemplate": "template1",
+            "project_languages": ["en", "es"],
+            "project_objectives": ["obj1"],
+            "project_template": "off",
+            "project_localvariety": "1",
+        }
+
+        self.view._ = MagicMock(
+            return_value="The names that the items will receive should be different."
+        )
+
+        result = self.view.processView()
+        # self.assertEqual(result, {'activeProject': {'DATA_ACTIVE_PROJECT': 'DATA_1'}, 'indashboard': True, 'data': {'project_localvariety': 'on', 'project_cod': 'VALUE123', 'project_registration_and_analysis': 1, 'project_languages': ['en', 'es'], 'project_objectives': ['obj1'], 'project_location': 'CLIMMOB', 'project_unit_of_analysis': '1'}, 'newproject': False, 'countries': ['DATA_2_A', 'DATA_2_B'], 'error_summary': {'dberror': 'Error to modify'}, 'listOfTemplates': {'DATA_TEMPLATES': 'DATA_3'}, 'listOfLanguages': {'DATA_LIST_LANG_BT_USER': {'DATA_4_B', 'DATA_4_A'}}, 'listOfLocations': {'DATA_ALL_PROJECT_LOC': 'DATA_5'}, 'listOfUnitOfAnalysis': {'DATA_ALL_UNIT_ANA_LOC': 'DATA_5'}, 'listOfObjectives': {'DATA_ALL_OBJECT_&_UNIT_OF_ANA': 'DATA_6'}, 'list_of_affiliation': {'DATA_ALL_AFFILIATIONS': 'DATA_7'}, 'plugin1': True, 'plugin2': 'ok'})
+        mock_get_the_project_id_for_owner.assert_called_with(
+            self.view.user.login, "testproject", self.view.request
+        )
+        mock_get_project_data.asssert_has_calls(
+            [call(1, self.view.request), call(1, self.view.request)]
+        )
+        mock_get_active_project.assert_called_once_with("testuser", self.view.request)
+        mock_get_country_list.assert_called_once_with(self.view.request)
+        mock_get_project_templates.assert_called_once_with(self.view.request, "1")
+        mock_get_list_of_languages_by_user.assert_called_once_with(
+            self.view.request, "testuser"
+        )
+        mock_get_all_project_location.assert_called_once_with(self.view.request)
+        mock_get_all_unit_of_analysis_by_location.assert_called_once_with(
+            self.view.request, "CLIMMOB"
+        )
+        mock_get_all_objectives_by_location_and_unit_of_analysis.assert_called_once_with(
+            self.view.request, "CLIMMOB", "1"
+        )
+        mock_get_all_affiliations.assert_called_once_with(self.view.request)
+
+    @patch("climmob.views.project.p.PluginImplementations")
+    @patch(
+        "climmob.views.project.get_all_affiliations",
+        return_value={"DATA_ALL_AFFILIATIONS": "DATA_7"},
+    )
+    @patch(
+        "climmob.views.project.get_all_objectives_by_location_and_unit_of_analysis",
+        return_value={"DATA_ALL_OBJECT_&_UNIT_OF_ANA": "DATA_6"},
+    )
+    @patch(
+        "climmob.views.project.get_all_unit_of_analysis_by_location",
+        return_value={"DATA_ALL_UNIT_ANA_LOC": "DATA_5"},
+    )
+    @patch(
+        "climmob.views.project.get_all_project_location",
+        return_value={"DATA_ALL_PROJECT_LOC": "DATA_5"},
+    )
+    @patch(
+        "climmob.views.project.getListOfLanguagesByUser",
+        return_value={"DATA_LIST_LANG_BT_USER": {"DATA_4_A", "DATA_4_B"}},
+    )
+    @patch(
+        "climmob.views.project.getProjectTemplates",
+        return_value={"DATA_TEMPLATES": "DATA_3"},
+    )
+    @patch(
+        "climmob.views.project.getCountryList", return_value=["DATA_2_A", "DATA_2_B"]
+    )
+    @patch(
+        "climmob.views.project.getActiveProject",
+        return_value={"DATA_ACTIVE_PROJECT": "DATA_1"},
+    )
+    @patch("climmob.views.project.getProjectData")
+    @patch("climmob.views.project.getTheProjectIdForOwner", return_value=1)
+    def test_process_view_modify_project_view_proj_error_in_plugin_to_modify(
+        self,
+        mock_get_the_project_id_for_owner,
+        mock_get_project_data,
+        mock_get_active_project,
+        mock_get_country_list,
+        mock_get_project_templates,
+        mock_get_list_of_languages_by_user,
+        mock_get_all_project_location,
+        mock_get_all_unit_of_analysis_by_location,
+        mock_get_all_objectives_by_location_and_unit_of_analysis,
+        mock_get_all_affiliations,
+        mock_plugin_implementations,
+    ):
+        mock_get_project_data.return_value = {
+            "project_regstatus": 1,
+            "project_numobs": 300,
+            "project_numcom": 2,
+            "project_registration_and_analysis": 1,
+            "project_template_used": "",
+            "project_cod": "VALUE123",
+            "project_objectives": ["obj1"],
+            "project_languages": ["en"],
+            "project_localvariety": 1,
+        }
+        self.view.request.POST = {
+            "btn_addNewProject": "1",
+            "project_cod": "VALUE123",
+            "project_registration_and_analysis": "1",
+            "project_location": "CLIMMOB",
+            "project_unit_of_analysis": "1",
+            "project_label_a": "PROJECT_LABEL_A",
+            "project_label_b": "PROJECT_LABEL_B",
+            "project_label_c": "PROJECT_LABEL_C",
+            "project_numobs": "30",
+            "project_numcom": "20",
+            "project_type": "off",
+            "usingTemplate": "template1",
+            "project_languages": ["en", "es"],
+            "project_objectives": ["obj1"],
+            "project_template": "off",
+            "project_localvariety": "1",
+        }
+        self.view.request.registry.settings = {
+            "projects.limit": "true",
+            "project.maximumnumberofobservations": "100",
+        }
+        plugin1 = MagicMock()
+        plugin2 = MagicMock()
+
+        plugin1.before_returning_project_context.side_effect = lambda req, ctx: {
+            **ctx,
+            "plugin1": True,
+        }
+        plugin2.before_returning_project_context.side_effect = lambda req, ctx: {
+            **ctx,
+            "plugin2": "ok",
+        }
+        mock_plugin_implementations.return_value = [plugin1, plugin2]
+        plugin1.before_updating_project.return_value = (
+            True,
+            "",
+            {
+                "project_localvariety": "1",
+                "project_cod": "VALUE123",
+                "project_registration_and_analysis": "1",
+                "project_languages": ["en", "es"],
+                "project_objectives": ["obj1"],
+                "project_location": "CLIMMOB",
+                "project_unit_of_analysis": "1",
+            },
+        )
+        plugin2.before_updating_project.return_value = (
+            False,
+            "Error to modify",
+            {
+                "project_localvariety": "1",
+                "project_cod": "VALUE123",
+                "project_registration_and_analysis": "1",
+                "project_languages": ["en", "es"],
+                "project_objectives": ["obj1"],
+                "project_location": "CLIMMOB",
+                "project_unit_of_analysis": "1",
+            },
+        )
+        result = self.view.processView()
+        self.assertEqual(
+            result,
+            {
+                "activeProject": {"DATA_ACTIVE_PROJECT": "DATA_1"},
+                "indashboard": True,
+                "data": {
+                    "project_localvariety": "1",
+                    "project_cod": "VALUE123",
+                    "project_registration_and_analysis": "1",
+                    "project_languages": ["en", "es"],
+                    "project_objectives": ["obj1"],
+                    "project_location": "CLIMMOB",
+                    "project_unit_of_analysis": "1",
+                },
+                "newproject": False,
+                "countries": ["DATA_2_A", "DATA_2_B"],
+                "error_summary": {"dberror": "Error to modify"},
+                "listOfTemplates": {"DATA_TEMPLATES": "DATA_3"},
+                "listOfLanguages": {"DATA_LIST_LANG_BT_USER": {"DATA_4_B", "DATA_4_A"}},
+                "listOfLocations": {"DATA_ALL_PROJECT_LOC": "DATA_5"},
+                "listOfUnitOfAnalysis": {"DATA_ALL_UNIT_ANA_LOC": "DATA_5"},
+                "listOfObjectives": {"DATA_ALL_OBJECT_&_UNIT_OF_ANA": "DATA_6"},
+                "list_of_affiliation": {"DATA_ALL_AFFILIATIONS": "DATA_7"},
+                "plugin1": True,
+                "plugin2": "ok",
+            },
+        )
+        mock_get_the_project_id_for_owner.assert_called_with(
+            self.view.user.login, "testproject", self.view.request
+        )
+        mock_get_project_data.asssert_has_calls(
+            [call(1, self.view.request), call(1, self.view.request)]
+        )
+        mock_get_active_project.assert_called_once_with("testuser", self.view.request)
+        mock_get_country_list.assert_called_once_with(self.view.request)
+        mock_get_project_templates.assert_called_once_with(self.view.request, "1")
+        mock_get_list_of_languages_by_user.assert_called_once_with(
+            self.view.request, "testuser"
+        )
+        mock_get_all_project_location.assert_called_once_with(self.view.request)
+        mock_get_all_unit_of_analysis_by_location.assert_called_once_with(
+            self.view.request, "CLIMMOB"
+        )
+        mock_get_all_objectives_by_location_and_unit_of_analysis.assert_called_once_with(
+            self.view.request, "CLIMMOB", "1"
+        )
+        mock_get_all_affiliations.assert_called_once_with(self.view.request)
+
+    @patch("climmob.views.project.p.PluginImplementations")
+    @patch("climmob.views.project.deleteRegistryByProjectId", return_value=(True, ""))
+    @patch("climmob.views.project.addPrjLang", return_value=(True, ""))
+    @patch("climmob.views.project.deleteAllPrjLang", return_value=(True, ""))
+    @patch(
+        "climmob.views.project.add_project_location_unit_objective",
+        return_value=(True, ""),
+    )
+    @patch(
+        "climmob.views.project.get_location_unit_of_analysis_objectives_by_combination",
+        return_value={"DATA_ALL_PROJECT_LOC": "DATA_8", "pluoaobj_id": 2},
+    )
+    @patch(
+        "climmob.views.project.delete_all_project_location_unit_objective",
+        return_value=(True, ""),
+    )
+    @patch("climmob.views.project.modifyProject", return_value=(True, ""))
+    @patch("climmob.views.project.get_location_unit_of_analysis_by_combination")
+    @patch("climmob.views.project.getProjectData")
+    @patch("climmob.views.project.getTheProjectIdForOwner", return_value=1)
+    def test_process_view_modify_project_view_proj_deleted_by_project(
+        self,
+        mock_get_the_project_id_for_owner,
+        mock_get_project_data,
+        mock_get_location_unit_of_analysis_by_combination,
+        mock_modify_project,
+        mock_delete_all_project_location_unit_objective,
+        mock_get_location_unit_of_analysis_objectives_by_combination,
+        mock_add_project_location_unit_objective,
+        mock_delete_all_prj_lang,
+        mock_add_prj_lang,
+        mock_delete_registry_by_project_id,
+        mock_plugin_implementations,
+    ):
+        mock_get_project_data.return_value = {
+            "project_regstatus": 1,
+            "project_numobs": 300,
+            "project_numcom": 2,
+            "project_registration_and_analysis": 1,
+            "project_template_used": "",
+            "project_cod": "VALUE123",
+            "project_objectives": "obj1",
+            "project_languages": "es",
+            "project_localvariety": 1,
+        }
+        self.view.request.POST = {
+            "btn_addNewProject": "1",
+            "project_cod": "VALUE123",
+            "project_registration_and_analysis": "1",
+            "project_location": "CLIMMOB",
+            "project_unit_of_analysis": "1",
+            "project_label_a": "PROJECT_LABEL_A",
+            "project_label_b": "PROJECT_LABEL_B",
+            "project_label_c": "PROJECT_LABEL_C",
+            "project_numobs": "30",
+            "project_numcom": "20",
+            "project_type": "off",
+            "usingTemplate": "template1",
+            "project_languages": "es",
+            "project_objectives": "obj1",
+            "project_template": "off",
+            "project_localvariety": "1",
+        }
+        self.view.request.registry.settings = {
+            "projects.limit": "true",
+            "project.maximumnumberofobservations": "100",
+        }
+        plugin1 = MagicMock()
+        plugin2 = MagicMock()
+        mock_plugin_implementations.return_value = [plugin1, plugin2]
+        plugin1.before_returning_project_context.side_effect = lambda req, ctx: {
+            **ctx,
+            "plugin1": True,
+        }
+        plugin2.before_returning_project_context.side_effect = lambda req, ctx: {
+            **ctx,
+            "plugin2": "ok",
+        }
+        plugin1.before_updating_project.return_value = (
+            True,
+            "",
+            {
+                "project_localvariety": "1",
+                "project_cod": "VALUE123",
+                "project_registration_and_analysis": 0,
+                "project_languages": "es",
+                "project_objectives": "obj1",
+                "project_location": "CLIMMOB",
+                "project_unit_of_analysis": "1",
+            },
+        )
+        plugin2.before_updating_project.return_value = (
+            True,
+            "",
+            {
+                "project_localvariety": "1",
+                "project_cod": "VALUE123",
+                "project_registration_and_analysis": 0,
+                "project_languages": "es",
+                "project_objectives": "obj1",
+                "project_location": "CLIMMOB",
+                "project_unit_of_analysis": "1",
+            },
+        )
+
+        mock_get_location_unit_of_analysis_by_combination.return_value = {
+            "pluoa_id": "2",
+            "plocation_id": 1,
+            "puoa_id": 2,
+            "registration_and_analysis": 0,
+        }
+        result = self.view.processView()
+        self.assertIsInstance(result, HTTPFound)
+        mock_get_the_project_id_for_owner.assert_has_calls(
+            [call(self.view.user.login, "testproject", self.view.request)]
+        )
+        mock_get_project_data.asssert_has_calls(
+            [call(1, self.view.request), call(1, self.view.request)]
+        )
+        mock_get_location_unit_of_analysis_by_combination.assert_called_once_with(
+            self.view.request, "CLIMMOB", "1"
+        )
+        mock_modify_project.assert_called_once_with(
+            1,
+            {
+                "project_localvariety": "1",
+                "project_cod": "VALUE123",
+                "project_registration_and_analysis": 0,
+                "project_languages": ["es"],
+                "project_objectives": ["obj1"],
+                "project_location": "CLIMMOB",
+                "project_unit_of_analysis": "1",
+            },
+            self.view.request,
+        )
+        mock_delete_all_project_location_unit_objective.assert_called_once_with(
+            1, self.view.request
+        )
+        mock_get_location_unit_of_analysis_objectives_by_combination.assert_called_once_with(
+            self.view.request, "2", "obj1"
+        )
+        mock_add_project_location_unit_objective.assert_called_once_with(
+            {"project_id": 1, "pluoaobj_id": 2}, self.view.request
+        )
+        mock_delete_all_prj_lang.assert_called_once_with(1, self.view.request)
+        mock_add_prj_lang.assert_called_once_with(
+            {"lang_default": 1, "lang_code": "es", "project_id": 1}, self.view.request
+        )
+        mock_delete_registry_by_project_id.assert_called_once_with(1, self.view.request)
+
+    @patch("climmob.views.project.p.PluginImplementations")
+    @patch(
+        "climmob.views.project.get_all_affiliations",
+        return_value={"DATA_ALL_AFFILIATIONS": "DATA_7"},
+    )
+    @patch(
+        "climmob.views.project.get_all_objectives_by_location_and_unit_of_analysis",
+        return_value={"DATA_ALL_OBJECT_&_UNIT_OF_ANA": "DATA_6"},
+    )
+    @patch(
+        "climmob.views.project.get_all_unit_of_analysis_by_location",
+        return_value={"DATA_ALL_UNIT_ANA_LOC": "DATA_5"},
+    )
+    @patch(
+        "climmob.views.project.get_all_project_location",
+        return_value={"DATA_ALL_PROJECT_LOC": "DATA_5"},
+    )
+    @patch(
+        "climmob.views.project.getListOfLanguagesByUser",
+        return_value={"DATA_LIST_LANG_BT_USER": {"DATA_4_A", "DATA_4_B"}},
+    )
+    @patch(
+        "climmob.views.project.getProjectTemplates",
+        return_value={"DATA_TEMPLATES": "DATA_3"},
+    )
+    @patch(
+        "climmob.views.project.getCountryList", return_value=["DATA_2_A", "DATA_2_B"]
+    )
+    @patch(
+        "climmob.views.project.getActiveProject",
+        return_value={"DATA_ACTIVE_PROJECT": "DATA_1"},
+    )
+    @patch(
+        "climmob.views.project.modifyProject", return_value=(False, "Error to modify")
+    )
+    @patch("climmob.views.project.get_location_unit_of_analysis_by_combination")
+    @patch("climmob.views.project.getProjectData")
+    @patch("climmob.views.project.getTheProjectIdForOwner", return_value=1)
+    def test_process_view_modify_project_view_proj_error_to_modify2(
+        self,
+        mock_get_the_project_id_for_owner,
+        mock_get_project_data,
+        mock_get_location_unit_of_analysis_by_combination,
+        mock_modify_project,
+        mock_get_active_project,
+        mock_get_country_list,
+        mock_get_project_templates,
+        mock_get_list_of_languages_by_user,
+        mock_get_all_project_location,
+        mock_get_all_unit_of_analysis_by_location,
+        mock_get_all_objectives_by_location_and_unit_of_analysis,
+        mock_get_all_affiliations,
+        mock_plugin_implementations,
+    ):
+        mock_get_project_data.return_value = {
+            "project_regstatus": 1,
+            "project_numobs": 300,
+            "project_numcom": 2,
+            "project_registration_and_analysis": 1,
+            "project_template_used": "",
+            "project_cod": "VALUE123",
+            "project_objectives": ["obj1"],
+            "project_languages": ["en"],
+            "project_localvariety": 1,
+        }
+        self.view.request.POST = {
+            "btn_addNewProject": "1",
+            "project_cod": "VALUE123",
+            "project_registration_and_analysis": "1",
+            "project_location": "CLIMMOB",
+            "project_unit_of_analysis": "1",
+            "project_label_a": "PROJECT_LABEL_A",
+            "project_label_b": "PROJECT_LABEL_B",
+            "project_label_c": "PROJECT_LABEL_C",
+            "project_numobs": "30",
+            "project_numcom": "20",
+            "project_type": "off",
+            "usingTemplate": "template1",
+            "project_languages": ["en", "es"],
+            "project_objectives": ["obj1"],
+            "project_template": "off",
+            "project_localvariety": "1",
+        }
+        self.view.request.registry.settings = {
+            "projects.limit": "true",
+            "project.maximumnumberofobservations": "100",
+        }
+        plugin1 = MagicMock()
+        plugin2 = MagicMock()
+
+        plugin1.before_returning_project_context.side_effect = lambda req, ctx: {
+            **ctx,
+            "plugin1": True,
+        }
+        plugin2.before_returning_project_context.side_effect = lambda req, ctx: {
+            **ctx,
+            "plugin2": "ok",
+        }
+        mock_plugin_implementations.return_value = [plugin1, plugin2]
+        plugin1.before_updating_project.return_value = (
+            True,
+            "",
+            {
+                "project_localvariety": "1",
+                "project_cod": "VALUE123",
+                "project_registration_and_analysis": "1",
+                "project_languages": ["en", "es"],
+                "project_objectives": ["obj1"],
+                "project_location": "CLIMMOB",
+                "project_unit_of_analysis": "1",
+            },
+        )
+        plugin2.before_updating_project.return_value = (
+            True,
+            "",
+            {
+                "project_localvariety": "1",
+                "project_cod": "VALUE123",
+                "project_registration_and_analysis": "1",
+                "project_languages": ["en", "es"],
+                "project_objectives": ["obj1"],
+                "project_location": "CLIMMOB",
+                "project_unit_of_analysis": "1",
+            },
+        )
+        self.view._ = MagicMock(
+            return_value="This project does not comply with the limitations on the number of participants per project."
+        )
+
+        mock_get_location_unit_of_analysis_by_combination.return_value = {
+            "pluoa_id": 2,
+            "plocation_id": 1,
+            "puoa_id": 2,
+            "registration_and_analysis": 0,
+        }
+        result = self.view.processView()
+        self.assertEqual(
+            result,
+            {
+                "activeProject": {"DATA_ACTIVE_PROJECT": "DATA_1"},
+                "indashboard": True,
+                "data": {
+                    "project_localvariety": "on",
+                    "project_cod": "VALUE123",
+                    "project_registration_and_analysis": 0,
+                    "project_languages": ["en", "es"],
+                    "project_objectives": ["obj1"],
+                    "project_location": "CLIMMOB",
+                    "project_unit_of_analysis": "1",
+                },
+                "newproject": False,
+                "countries": ["DATA_2_A", "DATA_2_B"],
+                "error_summary": {"dberror": "Error to modify"},
+                "listOfTemplates": {"DATA_TEMPLATES": "DATA_3"},
+                "listOfLanguages": {"DATA_LIST_LANG_BT_USER": {"DATA_4_B", "DATA_4_A"}},
+                "listOfLocations": {"DATA_ALL_PROJECT_LOC": "DATA_5"},
+                "listOfUnitOfAnalysis": {"DATA_ALL_UNIT_ANA_LOC": "DATA_5"},
+                "listOfObjectives": {"DATA_ALL_OBJECT_&_UNIT_OF_ANA": "DATA_6"},
+                "list_of_affiliation": {"DATA_ALL_AFFILIATIONS": "DATA_7"},
+                "plugin1": True,
+                "plugin2": "ok",
+            },
+        )
+        mock_get_the_project_id_for_owner.assert_called_with(
+            self.view.user.login, "testproject", self.view.request
+        )
+        mock_get_project_data.asssert_has_calls(
+            [call(1, self.view.request), call(1, self.view.request)]
+        )
+        mock_get_location_unit_of_analysis_by_combination.assert_called_once_with(
+            self.view.request, "CLIMMOB", "1"
+        )
+        mock_modify_project.assert_called_once_with(
+            1,
+            {
+                "project_localvariety": "on",
+                "project_cod": "VALUE123",
+                "project_registration_and_analysis": 0,
+                "project_languages": ["en", "es"],
+                "project_objectives": ["obj1"],
+                "project_location": "CLIMMOB",
+                "project_unit_of_analysis": "1",
+            },
+            self.view.request,
+        )
+        mock_get_active_project.assert_called_once_with("testuser", self.view.request)
+        mock_get_country_list.assert_called_once_with(self.view.request)
+        mock_get_project_templates.assert_called_once_with(self.view.request, 0)
+        mock_get_list_of_languages_by_user.assert_called_once_with(
+            self.view.request, "testuser"
+        )
+        mock_get_all_project_location.assert_called_once_with(self.view.request)
+        mock_get_all_unit_of_analysis_by_location.assert_called_once_with(
+            self.view.request, "CLIMMOB"
+        )
+        mock_get_all_objectives_by_location_and_unit_of_analysis.assert_called_once_with(
+            self.view.request, "CLIMMOB", "1"
+        )
+        mock_get_all_affiliations.assert_called_once_with(self.view.request)
+
+
+class TestGetTemplatesByTypeOfProjectView(BaseViewTestCase):
+    view_class = GetTemplatesByTypeOfProjectView
+
+    @patch("climmob.views.project.getProjectTemplates", return_value={"data": "data"})
+    def test_process_view_get_templates_by_type_of_project_view_success(
+        self, mock_get_project_templates
+    ):
+        self.view.request.matchdict = {"typeid": 0}
+        result = self.view.processView()
+        self.assertEqual(result, {"data": "data"})
+        mock_get_project_templates.assert_called_once_with(self.view.request, 0)
+
+    def test_process_view_get_templates_by_type_of_project_view_method_error(self):
+        self.view.request.method = "POST"
+        with self.assertRaises(HTTPNotFound) as context:
+            self.view.processView()
+        self.assertEqual(context.exception.code, 404)
+
+
+class TestProjectListView(BaseViewTestCase):
+    view_class = ProjectListView
+
+    @patch(
+        "climmob.views.project.getTotalNumberOfProjectsInClimMob",
+        return_value={"data2": "data2"},
+    )
+    @patch("climmob.views.project.getUserProjects", return_value={"data1": "data1"})
+    @patch("climmob.views.project.getActiveProject", return_value={"data": "data"})
+    def test_project_list_view_success(
+        self,
+        mock_get_active_project,
+        mock_get_user_projects,
+        mock_get_total_projects_in_climmob,
+    ):
+        result = self.view.processView()
+        self.assertEqual(
+            result,
+            {
+                "activeProject": {"data": "data"},
+                "numberOfProjects": {"data2": "data2"},
+                "sectionActive": "projectlist",
+                "userProjects": {"data1": "data1"},
+            },
+        )
+        mock_get_active_project.assert_called_once_with(
+            self.view.user.login, self.view.request
+        )
+        mock_get_user_projects.assert_called_once_with(
+            self.view.user.login, self.view.request
+        )
+        mock_get_total_projects_in_climmob.assert_called_once_with(self.view.request)
+
+
+class TestDeleteProjectView(BaseViewTestCase):
+    view_class = DeleteProjectView
+    request_method = "POST"
+
+    @patch("climmob.views.project.getProjectData", return_value={"data": "data"})
+    @patch("climmob.views.project.getTheProjectIdForOwner", return_value=1)
+    def test_process_view_delete_project_view_method_error(
+        self, mock_get_the_project_id_for_owner, mock_get_project_data
+    ):
+        self.view.request.matchdict = {"user": "TEST_USER", "project": "TEST_PROJECT"}
+        self.view.request.method = "GET"
+        result = self.view.processView()
+        self.assertEqual(
+            result,
+            {
+                "activeUser": self.view.user,
+                "redirect": False,
+                "data": {"data": "data"},
+                "error_summary": {},
+            },
+        )
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "TEST_USER", "TEST_PROJECT", self.view.request
+        )
+        mock_get_project_data.assert_called_once_with(1, self.view.request)
+
+    @patch("climmob.views.project.p.PluginImplementations")
+    @patch("climmob.views.project.getProjectData", return_value={"data": "data"})
+    @patch("climmob.views.project.getTheProjectIdForOwner", return_value=1)
+    def test_process_view_delete_project_view_error_to_delete(
+        self,
+        mock_get_the_project_id_for_owner,
+        mock_get_project_data,
+        mock_plugin_implementations,
+    ):
+        self.view.request.matchdict = {"user": "TEST_USER", "project": "TEST_PROJECT"}
+        plugin1 = MagicMock()
+        plugin2 = MagicMock()
+        mock_plugin_implementations.return_value = [plugin1, plugin2]
+        plugin1.before_deleting_project.return_value = (False, "Error to delete")
+        plugin2.before_deleting_project.return_value = (False, "Error to delete")
+
+        result = self.view.processView()
+        self.assertEqual(result, {"status": 400, "error": "Error to delete"})
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "TEST_USER", "TEST_PROJECT", self.view.request
+        )
+        mock_get_project_data.assert_called_once_with(1, self.view.request)
+
+    @patch(
+        "climmob.views.project.deleteProject",
+        return_value=(False, "Error to delete project"),
+    )
+    @patch("climmob.views.project.p.PluginImplementations")
+    @patch("climmob.views.project.getProjectData", return_value={"data": "data"})
+    @patch("climmob.views.project.getTheProjectIdForOwner", return_value=1)
+    def test_process_view_delete_project_view_error_to_delete_project(
+        self,
+        mock_get_the_project_id_for_owner,
+        mock_get_project_data,
+        mock_plugin_implementations,
+        mock_delete_project,
+    ):
+        self.view.request.matchdict = {"user": "TEST_USER", "project": "TEST_PROJECT"}
+        plugin1 = MagicMock()
+        plugin2 = MagicMock()
+        mock_plugin_implementations.return_value = [plugin1, plugin2]
+        plugin1.before_deleting_project.return_value = (True, "")
+        plugin2.before_deleting_project.return_value = (True, "")
+
+        result = self.view.processView()
+        self.assertEqual(result, {"status": 400, "error": "Error to delete project"})
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "TEST_USER", "TEST_PROJECT", self.view.request
+        )
+        mock_get_project_data.assert_called_once_with(1, self.view.request)
+        mock_delete_project.assert_called_once_with(1, self.view.request)
+
+    @patch("climmob.views.project.deleteProject", return_value=(True, ""))
+    @patch("climmob.views.project.p.PluginImplementations")
+    @patch("climmob.views.project.getProjectData", return_value={"data": "data"})
+    @patch("climmob.views.project.getTheProjectIdForOwner", return_value=1)
+    def test_process_view_delete_project_view_success(
+        self,
+        mock_get_the_project_id_for_owner,
+        mock_get_project_data,
+        mock_plugin_implementations,
+        mock_delete_project,
+    ):
+        self.view.request.matchdict = {"user": "TEST_USER", "project": "TEST_PROJECT"}
+        plugin1 = MagicMock()
+        plugin2 = MagicMock()
+        mock_plugin_implementations.return_value = [plugin1, plugin2]
+        plugin1.before_deleting_project.return_value = (True, "")
+        plugin2.before_deleting_project.return_value = (True, "")
+
+        plugin1.after_deleting_project.return_value = None
+        plugin2.after_deleting_project.return_value = None
+
+        result = self.view.processView()
+        self.assertEqual(result, {"status": 200})
+        self.view.request.session.flash.assert_called_once_with(
+            "The project was deleted successfully"
+        )
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "TEST_USER", "TEST_PROJECT", self.view.request
+        )
+        mock_get_project_data.assert_called_once_with(1, self.view.request)
+        mock_delete_project.assert_called_once_with(1, self.view.request)
 
 
 if __name__ == "__main__":

--- a/climmob/tests/test_utils/test_views_project.py
+++ b/climmob/tests/test_utils/test_views_project.py
@@ -1,9 +1,18 @@
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, ANY
+
+from formencode.variabledecode import variable_decode
+from pyramid.httpexceptions import HTTPNotFound, HTTPFound
+
 from climmob.views.project import (
     GetUnitOfAnalysisByLocationView,
     GetObjectivesByLocationAndUnitOfAnalysisView,
+    NewProjectView,
+create_project_function,
+ModifyProjectView
 )
+from climmob.tests.test_utils.common import BaseViewTestCase
+
 
 
 class TestGetUnitOfAnalysisByLocationView(unittest.TestCase):
@@ -63,7 +72,7 @@ class TestGetObjectivesByLocationAndUnitOfAnalysisView(unittest.TestCase):
 
     @patch("climmob.views.project.get_all_objectives_by_location_and_unit_of_analysis")
     def test_process_view_get(
-        self, mock_get_all_objectives_by_location_and_unit_of_analysis
+            self, mock_get_all_objectives_by_location_and_unit_of_analysis
     ):
         self.mock_request.method = "GET"
 
@@ -98,3 +107,246 @@ class TestGetObjectivesByLocationAndUnitOfAnalysisView(unittest.TestCase):
         result = self.view.processView()
 
         self.assertEqual(result, {})
+
+class TestNewProjectView(BaseViewTestCase):
+    view_class = NewProjectView
+    request_method = "POST"
+
+    def setup(self):
+        super().setUp()
+        self.view.request.registry.settings = {"projects.limit": "false"}
+        self.view.request.POST = {
+            "submit": "1",
+            "btn_addNewProject": "1",
+            "project_cod": "VALUE123",
+            "project_registration_and_analysis": '1',
+            "project_location": "CLIMMOB",
+            "project_unit_of_analysis": "1",
+        }
+
+    @patch("climmob.views.project.getTotalNumberOfProjectsInClimMob", return_value=0)
+    def test_process_view_new_project_view_project_limits_true(self, mock_get_total_number_of_projects_in_climmob):
+        self.view.request.registry.settings = {"projects.limit": "true", "projects.quantity": 0}
+        with self.assertRaises(HTTPNotFound) as context:
+            self.view.processView()
+        self.assertEqual(context.exception.code, 404)
+        mock_get_total_number_of_projects_in_climmob.assert_called_once_with(self.view.request)
+
+    @patch("climmob.views.project.get_all_affiliations", return_value="LIST_AFFILIATIONS")
+    @patch("climmob.views.project.get_all_objectives_by_location_and_unit_of_analysis", return_value="OBJECTIVES_AND_UNIT_OF_ANALYSIS")
+    @patch("climmob.views.project.get_all_unit_of_analysis_by_location", return_value="UNIT_OF_ANALYSIS")
+    @patch("climmob.views.project.get_all_project_location", return_value="PROJECT_LOCATION")
+    @patch("climmob.views.project.getListOfLanguagesByUser", return_value="LIST_OF_LANGUAGES")
+    @patch("climmob.views.project.getProjectTemplates", return_value="PROJECT_TEMPLATES")
+    @patch("climmob.views.project.getActiveProject", return_value="ACTIVE_PROJECT_INFO")
+    @patch("climmob.views.project.create_project_function", return_value=({},"This project does not comply with the limitations on the number of participants per project.",False))
+    def test_process_view_new_project_view_post_no_added(self, mock_create_project_function, mock_get_active_project, mock_get_project_templates, mock_get_list_of_languages_by_user, mock_get_all_project_location,mock_get_all_unit_of_analysis_by_location,mock_get_all_objectives_by_location_and_unit_of_analysis, mock_get_all_affiliations):
+        self.view.user.fullName = "SOME_VALUE",
+        self.view.user.email = "CLIMMOB@EXAMPLE.COM",
+        result = self.view.processView()
+        self.assertEqual(result, {
+            'activeProject': 'ACTIVE_PROJECT_INFO',
+            'indashboard': True,
+            'dataworking': {
+                'project_cod': '',
+                'project_name': '',
+                'project_abstract': '',
+                'project_tags': '',
+                'project_pi': ('SOME_VALUE',),
+                'project_piemail': ('CLIMMOB@EXAMPLE.COM',),
+                'project_numobs': 0,
+                'project_numcom': 3,
+                'project_regstatus': 0,
+                'project_localvariety': 'on',
+                'project_cnty': None,
+                'project_registration_and_analysis': 0,
+                'project_label_a': 'Option A',
+                'project_label_b': 'Option B',
+                'project_label_c': 'Option C',
+                'project_template': 0,
+                'usingTemplate': '',
+                'project_location': '-1',
+                'project_unit_of_analysis': '-1'
+            },
+            'newproject': False,
+            'countries': [],
+            'error_summary': {},
+            'listOfTemplates': 'PROJECT_TEMPLATES',
+            'listOfLanguages': 'LIST_OF_LANGUAGES',
+            'listOfLocations': 'PROJECT_LOCATION',
+            'listOfUnitOfAnalysis': 'UNIT_OF_ANALYSIS',
+            'listOfObjectives': 'OBJECTIVES_AND_UNIT_OF_ANALYSIS',
+            'list_of_affiliation': 'LIST_AFFILIATIONS'
+        })
+        mock_get_active_project.assert_called_once_with(self.view.user.login, self.view.request)
+        mock_get_project_templates.assert_called_once_with(self.view.request,0)
+        mock_get_list_of_languages_by_user.assert_called_once_with(self.view.request, self.view.user.login)
+        mock_get_all_project_location.assert_called_once_with(self.view.request)
+        mock_get_all_unit_of_analysis_by_location.assert_called_once_with(self.view.request, "-1" )
+        mock_get_all_objectives_by_location_and_unit_of_analysis.assert_called_once_with(self.view.request, "-1" , "-1")
+        mock_get_all_affiliations.assert_called_once_with(self.view.request)
+
+    @patch("climmob.views.project.create_project_function")
+    def test_process_view_new_project_view_post_success(self, mock_create_project_function):
+        self.view.request.POST = {
+            "submit": "1",
+            "btn_addNewProject": "1",
+            "project_cod": "VALUE123",
+            "project_registration_and_analysis": '1',
+            "project_location": "CLIMMOB",
+            "project_unit_of_analysis": "1",
+            "project_numobs":1,
+        }
+        mock_create_project_function.return_value = (
+            {"project_cod": "VALUE123"},
+            {},
+            True
+        )
+        self.view.user.fullName = "SOME_VALUE"
+        self.view.user.email = "CLIMMOB@EXAMPLE.COM"
+        result = self.view.processView()
+        self.assertIsInstance(result, HTTPFound)
+
+class TestModifyProjectView(BaseViewTestCase):
+    view_class = ModifyProjectView
+    request_method = "POST"
+
+    def setUp(self):
+        super().setUp()
+
+        self.view = ModifyProjectView(self.view.request)
+        self.view.request.matchdict = {
+            'user': 'testuser',
+            'project': 'testproject'
+        }
+        self.view.user = MagicMock()
+        self.view.user.login = 'testuser'
+        self.view.user.email = 'testuser@example.com'
+        self.view.user.fullName = 'COMPLETE_TEST_USER'
+        self.view.request.registry.settings = {
+            'projects.limit': 'false',
+            'project.maximumnumberofobservations': '100'
+        }
+
+    @patch('climmob.views.project.function_create_clone', return_value=1)
+    @patch('climmob.views.project.getProjectAssessments', return_value=[
+        {"ass_cod": "assessment1"},
+        {"ass_cod": "assessment2"},
+    ])
+    @patch('climmob.views.project.deleteProjectAssessments', return_value=(True, ""))
+    @patch('climmob.views.project.deleteRegistryByProjectId', return_value=(True, ""))
+    @patch('climmob.views.project.addPrjLang', return_value=(True, ""))
+    @patch('climmob.views.project.deleteAllPrjLang', return_value=(True, ""))
+    @patch('climmob.views.project.add_project_location_unit_objective', return_value=(True, ""))
+    @patch('climmob.views.project.get_location_unit_of_analysis_objectives_by_combination')
+    @patch('climmob.views.project.delete_all_project_location_unit_objective', return_value=(True, ""))
+    @patch('climmob.views.project.modifyProject', return_value= (True,""))
+    @patch('climmob.views.project.get_location_unit_of_analysis_by_combination')
+    @patch('climmob.views.project.getProjectData')
+    @patch('climmob.views.project.getTheProjectIdForOwner', return_value=1)
+    def test_processView_success(self, mock_get_the_project_id_for_owner, mock_get_project_data,
+                                 mock_get_location_unit_of_analysis_by_combination, mock_modify_project,
+                                 mock_delete_all_project_location_unit_objective, mock_get_location_unit_of_analysis_objectives_by_combination,
+                                 mock_add_project_location_unit_objective, mock_delete_all_frj_lang,mock_add_prj_lang,
+                                 mock_delete_registry_by_project_id, mock_delete_project_assessments, mock_get_project_assessments,
+                                 mock_function_create_clone):
+
+        mock_plugin = MagicMock()
+        mock_plugin.before_updating_project.return_value = (True,"","data")
+
+        mock_plugin.before_updating_project.return_value = (True, "", "data")
+
+        self.view.request.POST = {
+            'btn_addNewProject': '1',
+            'project_cod': 'VALUE123',
+            'project_registration_and_analysis': '1',
+            'project_location': 'CLIMMOB',
+            'project_unit_of_analysis': '1',
+            'project_label_a': 'PROJECT_LABEL_A',
+            'project_label_b': 'PROJECT_LABEL_B',
+            'project_label_c': 'PROJECT_LABEL_C',
+            'project_numobs': '20',
+            'project_numcom': '20',
+            'project_localvariety': 1,
+            'project_type': 'on',
+            'project_template': 'on',
+            'usingTemplate': 'template1',
+            'project_languages': ['en', 'es'],
+            "testproject": "true"
+        }
+
+        mock_get_project_data.return_value = {
+            'project_localvariety': 1,
+            'project_regstatus': 0,
+            'project_numobs': 3,
+            'project_numcom': 2,
+            'project_registration_and_analysis': 1,
+            'project_template_used': '',
+            'project_cod': 'VALUE123',
+            'project_objectives': ['obj1'],
+            'project_languages': ['en'],
+            "testproject": "true"
+        }
+
+        self.view.getPostDict = MagicMock(return_value={
+            'project_cod': 'VALUE123',
+            'project_registration_and_analysis': '1',
+            'project_location': 'CLIMMOB',
+            'project_unit_of_analysis': '1',
+            'project_label_a': 'Label A',
+            'project_label_b': 'Label B',
+            'project_label_c': 'Label C',
+            'project_numobs': '3',
+            'project_numcom': '2',
+            'project_localvariety': '1',
+            'project_type': 'on',
+            'project_template': 'on',
+            'usingTemplate': 'template1',  # <-- Cambiado aquí
+            'project_languages': ['en'],
+            'project_objectives': ['obj1'],
+            "testproject": "true"
+        })
+
+        mock_get_location_unit_of_analysis_by_combination.return_value = {
+            "pluoa_id":2,
+            "plocation_id":1,
+            "puoa_id": 2,
+            "registration_and_analysis": 12,
+
+        }
+
+        mock_get_location_unit_of_analysis_objectives_by_combination.return_value = {
+            "pluoaobj_id":2,
+            "pluoa_id": 2,
+            "pobjective_id": 1,
+
+        }
+        result = self.view.processView()
+
+        self.assertIsInstance(result, HTTPFound)
+        mock_get_the_project_id_for_owner.assert_called_with(
+            self.view.user.login, 'testproject', self.view.request
+        )
+        assert mock_get_project_data.call_count >= 2
+
+        mock_get_location_unit_of_analysis_by_combination.assert_called_once_with(
+            self.view.request, 'CLIMMOB', '1'
+        )
+
+        mock_modify_project.assert_called_once()
+        mock_modify_project.assert_called_with(1, ANY, self.view.request)
+        mock_delete_all_project_location_unit_objective.assert_called_once_with(1, self.view.request)
+        mock_get_location_unit_of_analysis_objectives_by_combination.assert_called()
+        mock_add_project_location_unit_objective.assert_called()
+        mock_delete_all_frj_lang.assert_called_once_with(1, self.view.request)
+        mock_add_prj_lang.assert_called()
+        mock_delete_registry_by_project_id.assert_called()
+        mock_delete_project_assessments.assert_called()
+        mock_get_project_assessments.assert_called()
+        mock_function_create_clone.assert_called_once()
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/climmob/tests/test_utils/test_views_project.py
+++ b/climmob/tests/test_utils/test_views_project.py
@@ -1,18 +1,15 @@
 import unittest
 from unittest.mock import MagicMock, patch, ANY
 
-from formencode.variabledecode import variable_decode
 from pyramid.httpexceptions import HTTPNotFound, HTTPFound
 
+from climmob.tests.test_utils.common import BaseViewTestCase
 from climmob.views.project import (
     GetUnitOfAnalysisByLocationView,
     GetObjectivesByLocationAndUnitOfAnalysisView,
     NewProjectView,
-create_project_function,
-ModifyProjectView
+    ModifyProjectView,
 )
-from climmob.tests.test_utils.common import BaseViewTestCase
-
 
 
 class TestGetUnitOfAnalysisByLocationView(unittest.TestCase):
@@ -72,7 +69,7 @@ class TestGetObjectivesByLocationAndUnitOfAnalysisView(unittest.TestCase):
 
     @patch("climmob.views.project.get_all_objectives_by_location_and_unit_of_analysis")
     def test_process_view_get(
-            self, mock_get_all_objectives_by_location_and_unit_of_analysis
+        self, mock_get_all_objectives_by_location_and_unit_of_analysis
     ):
         self.mock_request.method = "GET"
 
@@ -108,6 +105,7 @@ class TestGetObjectivesByLocationAndUnitOfAnalysisView(unittest.TestCase):
 
         self.assertEqual(result, {})
 
+
 class TestNewProjectView(BaseViewTestCase):
     view_class = NewProjectView
     request_method = "POST"
@@ -119,93 +117,147 @@ class TestNewProjectView(BaseViewTestCase):
             "submit": "1",
             "btn_addNewProject": "1",
             "project_cod": "VALUE123",
-            "project_registration_and_analysis": '1',
+            "project_registration_and_analysis": "1",
             "project_location": "CLIMMOB",
             "project_unit_of_analysis": "1",
         }
 
     @patch("climmob.views.project.getTotalNumberOfProjectsInClimMob", return_value=0)
-    def test_process_view_new_project_view_project_limits_true(self, mock_get_total_number_of_projects_in_climmob):
-        self.view.request.registry.settings = {"projects.limit": "true", "projects.quantity": 0}
+    def test_process_view_new_project_view_project_limits_true(
+        self, mock_get_total_number_of_projects_in_climmob
+    ):
+        self.view.request.registry.settings = {
+            "projects.limit": "true",
+            "projects.quantity": 0,
+        }
         with self.assertRaises(HTTPNotFound) as context:
             self.view.processView()
         self.assertEqual(context.exception.code, 404)
-        mock_get_total_number_of_projects_in_climmob.assert_called_once_with(self.view.request)
+        mock_get_total_number_of_projects_in_climmob.assert_called_once_with(
+            self.view.request
+        )
 
-    @patch("climmob.views.project.get_all_affiliations", return_value="LIST_AFFILIATIONS")
-    @patch("climmob.views.project.get_all_objectives_by_location_and_unit_of_analysis", return_value="OBJECTIVES_AND_UNIT_OF_ANALYSIS")
-    @patch("climmob.views.project.get_all_unit_of_analysis_by_location", return_value="UNIT_OF_ANALYSIS")
-    @patch("climmob.views.project.get_all_project_location", return_value="PROJECT_LOCATION")
-    @patch("climmob.views.project.getListOfLanguagesByUser", return_value="LIST_OF_LANGUAGES")
-    @patch("climmob.views.project.getProjectTemplates", return_value="PROJECT_TEMPLATES")
+    @patch(
+        "climmob.views.project.get_all_affiliations", return_value="LIST_AFFILIATIONS"
+    )
+    @patch(
+        "climmob.views.project.get_all_objectives_by_location_and_unit_of_analysis",
+        return_value="OBJECTIVES_AND_UNIT_OF_ANALYSIS",
+    )
+    @patch(
+        "climmob.views.project.get_all_unit_of_analysis_by_location",
+        return_value="UNIT_OF_ANALYSIS",
+    )
+    @patch(
+        "climmob.views.project.get_all_project_location",
+        return_value="PROJECT_LOCATION",
+    )
+    @patch(
+        "climmob.views.project.getListOfLanguagesByUser",
+        return_value="LIST_OF_LANGUAGES",
+    )
+    @patch(
+        "climmob.views.project.getProjectTemplates", return_value="PROJECT_TEMPLATES"
+    )
     @patch("climmob.views.project.getActiveProject", return_value="ACTIVE_PROJECT_INFO")
-    @patch("climmob.views.project.create_project_function", return_value=({},"This project does not comply with the limitations on the number of participants per project.",False))
-    def test_process_view_new_project_view_post_no_added(self, mock_create_project_function, mock_get_active_project, mock_get_project_templates, mock_get_list_of_languages_by_user, mock_get_all_project_location,mock_get_all_unit_of_analysis_by_location,mock_get_all_objectives_by_location_and_unit_of_analysis, mock_get_all_affiliations):
-        self.view.user.fullName = "SOME_VALUE",
-        self.view.user.email = "CLIMMOB@EXAMPLE.COM",
+    @patch(
+        "climmob.views.project.create_project_function",
+        return_value=(
+            {},
+            "This project does not comply with the limitations on the number of participants per project.",
+            False,
+        ),
+    )
+    def test_process_view_new_project_view_post_no_added(
+        self,
+        mock_create_project_function,
+        mock_get_active_project,
+        mock_get_project_templates,
+        mock_get_list_of_languages_by_user,
+        mock_get_all_project_location,
+        mock_get_all_unit_of_analysis_by_location,
+        mock_get_all_objectives_by_location_and_unit_of_analysis,
+        mock_get_all_affiliations,
+    ):
+        self.view.user.fullName = ("SOME_VALUE",)
+        self.view.user.email = ("CLIMMOB@EXAMPLE.COM",)
         result = self.view.processView()
-        self.assertEqual(result, {
-            'activeProject': 'ACTIVE_PROJECT_INFO',
-            'indashboard': True,
-            'dataworking': {
-                'project_cod': '',
-                'project_name': '',
-                'project_abstract': '',
-                'project_tags': '',
-                'project_pi': ('SOME_VALUE',),
-                'project_piemail': ('CLIMMOB@EXAMPLE.COM',),
-                'project_numobs': 0,
-                'project_numcom': 3,
-                'project_regstatus': 0,
-                'project_localvariety': 'on',
-                'project_cnty': None,
-                'project_registration_and_analysis': 0,
-                'project_label_a': 'Option A',
-                'project_label_b': 'Option B',
-                'project_label_c': 'Option C',
-                'project_template': 0,
-                'usingTemplate': '',
-                'project_location': '-1',
-                'project_unit_of_analysis': '-1'
+        self.assertEqual(
+            result,
+            {
+                "activeProject": "ACTIVE_PROJECT_INFO",
+                "indashboard": True,
+                "dataworking": {
+                    "project_cod": "",
+                    "project_name": "",
+                    "project_abstract": "",
+                    "project_tags": "",
+                    "project_pi": ("SOME_VALUE",),
+                    "project_piemail": ("CLIMMOB@EXAMPLE.COM",),
+                    "project_numobs": 0,
+                    "project_numcom": 3,
+                    "project_regstatus": 0,
+                    "project_localvariety": "on",
+                    "project_cnty": None,
+                    "project_registration_and_analysis": 0,
+                    "project_label_a": "Option A",
+                    "project_label_b": "Option B",
+                    "project_label_c": "Option C",
+                    "project_template": 0,
+                    "usingTemplate": "",
+                    "project_location": "-1",
+                    "project_unit_of_analysis": "-1",
+                },
+                "newproject": False,
+                "countries": [],
+                "error_summary": {},
+                "listOfTemplates": "PROJECT_TEMPLATES",
+                "listOfLanguages": "LIST_OF_LANGUAGES",
+                "listOfLocations": "PROJECT_LOCATION",
+                "listOfUnitOfAnalysis": "UNIT_OF_ANALYSIS",
+                "listOfObjectives": "OBJECTIVES_AND_UNIT_OF_ANALYSIS",
+                "list_of_affiliation": "LIST_AFFILIATIONS",
             },
-            'newproject': False,
-            'countries': [],
-            'error_summary': {},
-            'listOfTemplates': 'PROJECT_TEMPLATES',
-            'listOfLanguages': 'LIST_OF_LANGUAGES',
-            'listOfLocations': 'PROJECT_LOCATION',
-            'listOfUnitOfAnalysis': 'UNIT_OF_ANALYSIS',
-            'listOfObjectives': 'OBJECTIVES_AND_UNIT_OF_ANALYSIS',
-            'list_of_affiliation': 'LIST_AFFILIATIONS'
-        })
-        mock_get_active_project.assert_called_once_with(self.view.user.login, self.view.request)
-        mock_get_project_templates.assert_called_once_with(self.view.request,0)
-        mock_get_list_of_languages_by_user.assert_called_once_with(self.view.request, self.view.user.login)
+        )
+        mock_get_active_project.assert_called_once_with(
+            self.view.user.login, self.view.request
+        )
+        mock_get_project_templates.assert_called_once_with(self.view.request, 0)
+        mock_get_list_of_languages_by_user.assert_called_once_with(
+            self.view.request, self.view.user.login
+        )
         mock_get_all_project_location.assert_called_once_with(self.view.request)
-        mock_get_all_unit_of_analysis_by_location.assert_called_once_with(self.view.request, "-1" )
-        mock_get_all_objectives_by_location_and_unit_of_analysis.assert_called_once_with(self.view.request, "-1" , "-1")
+        mock_get_all_unit_of_analysis_by_location.assert_called_once_with(
+            self.view.request, "-1"
+        )
+        mock_get_all_objectives_by_location_and_unit_of_analysis.assert_called_once_with(
+            self.view.request, "-1", "-1"
+        )
         mock_get_all_affiliations.assert_called_once_with(self.view.request)
 
     @patch("climmob.views.project.create_project_function")
-    def test_process_view_new_project_view_post_success(self, mock_create_project_function):
+    def test_process_view_new_project_view_post_success(
+        self, mock_create_project_function
+    ):
         self.view.request.POST = {
             "submit": "1",
             "btn_addNewProject": "1",
             "project_cod": "VALUE123",
-            "project_registration_and_analysis": '1',
+            "project_registration_and_analysis": "1",
             "project_location": "CLIMMOB",
             "project_unit_of_analysis": "1",
-            "project_numobs":1,
+            "project_numobs": 1,
         }
         mock_create_project_function.return_value = (
             {"project_cod": "VALUE123"},
             {},
-            True
+            True,
         )
         self.view.user.fullName = "SOME_VALUE"
         self.view.user.email = "CLIMMOB@EXAMPLE.COM"
         result = self.view.processView()
         self.assertIsInstance(result, HTTPFound)
+
 
 class TestModifyProjectView(BaseViewTestCase):
     view_class = ModifyProjectView
@@ -215,127 +267,145 @@ class TestModifyProjectView(BaseViewTestCase):
         super().setUp()
 
         self.view = ModifyProjectView(self.view.request)
-        self.view.request.matchdict = {
-            'user': 'testuser',
-            'project': 'testproject'
-        }
+        self.view.request.matchdict = {"user": "testuser", "project": "testproject"}
         self.view.user = MagicMock()
-        self.view.user.login = 'testuser'
-        self.view.user.email = 'testuser@example.com'
-        self.view.user.fullName = 'COMPLETE_TEST_USER'
+        self.view.user.login = "testuser"
+        self.view.user.email = "testuser@example.com"
+        self.view.user.fullName = "COMPLETE_TEST_USER"
         self.view.request.registry.settings = {
-            'projects.limit': 'false',
-            'project.maximumnumberofobservations': '100'
+            "projects.limit": "false",
+            "project.maximumnumberofobservations": "100",
         }
 
-    @patch('climmob.views.project.function_create_clone', return_value=1)
-    @patch('climmob.views.project.getProjectAssessments', return_value=[
-        {"ass_cod": "assessment1"},
-        {"ass_cod": "assessment2"},
-    ])
-    @patch('climmob.views.project.deleteProjectAssessments', return_value=(True, ""))
-    @patch('climmob.views.project.deleteRegistryByProjectId', return_value=(True, ""))
-    @patch('climmob.views.project.addPrjLang', return_value=(True, ""))
-    @patch('climmob.views.project.deleteAllPrjLang', return_value=(True, ""))
-    @patch('climmob.views.project.add_project_location_unit_objective', return_value=(True, ""))
-    @patch('climmob.views.project.get_location_unit_of_analysis_objectives_by_combination')
-    @patch('climmob.views.project.delete_all_project_location_unit_objective', return_value=(True, ""))
-    @patch('climmob.views.project.modifyProject', return_value= (True,""))
-    @patch('climmob.views.project.get_location_unit_of_analysis_by_combination')
-    @patch('climmob.views.project.getProjectData')
-    @patch('climmob.views.project.getTheProjectIdForOwner', return_value=1)
-    def test_processView_success(self, mock_get_the_project_id_for_owner, mock_get_project_data,
-                                 mock_get_location_unit_of_analysis_by_combination, mock_modify_project,
-                                 mock_delete_all_project_location_unit_objective, mock_get_location_unit_of_analysis_objectives_by_combination,
-                                 mock_add_project_location_unit_objective, mock_delete_all_frj_lang,mock_add_prj_lang,
-                                 mock_delete_registry_by_project_id, mock_delete_project_assessments, mock_get_project_assessments,
-                                 mock_function_create_clone):
+    @patch("climmob.views.project.function_create_clone", return_value=1)
+    @patch(
+        "climmob.views.project.getProjectAssessments",
+        return_value=[
+            {"ass_cod": "assessment1"},
+            {"ass_cod": "assessment2"},
+        ],
+    )
+    @patch("climmob.views.project.deleteProjectAssessments", return_value=(True, ""))
+    @patch("climmob.views.project.deleteRegistryByProjectId", return_value=(True, ""))
+    @patch("climmob.views.project.addPrjLang", return_value=(True, ""))
+    @patch("climmob.views.project.deleteAllPrjLang", return_value=(True, ""))
+    @patch(
+        "climmob.views.project.add_project_location_unit_objective",
+        return_value=(True, ""),
+    )
+    @patch(
+        "climmob.views.project.get_location_unit_of_analysis_objectives_by_combination"
+    )
+    @patch(
+        "climmob.views.project.delete_all_project_location_unit_objective",
+        return_value=(True, ""),
+    )
+    @patch("climmob.views.project.modifyProject", return_value=(True, ""))
+    @patch("climmob.views.project.get_location_unit_of_analysis_by_combination")
+    @patch("climmob.views.project.getProjectData")
+    @patch("climmob.views.project.getTheProjectIdForOwner", return_value=1)
+    def test_processView_success(
+        self,
+        mock_get_the_project_id_for_owner,
+        mock_get_project_data,
+        mock_get_location_unit_of_analysis_by_combination,
+        mock_modify_project,
+        mock_delete_all_project_location_unit_objective,
+        mock_get_location_unit_of_analysis_objectives_by_combination,
+        mock_add_project_location_unit_objective,
+        mock_delete_all_frj_lang,
+        mock_add_prj_lang,
+        mock_delete_registry_by_project_id,
+        mock_delete_project_assessments,
+        mock_get_project_assessments,
+        mock_function_create_clone,
+    ):
 
         mock_plugin = MagicMock()
-        mock_plugin.before_updating_project.return_value = (True,"","data")
+        mock_plugin.before_updating_project.return_value = (True, "", "data")
 
         mock_plugin.before_updating_project.return_value = (True, "", "data")
 
         self.view.request.POST = {
-            'btn_addNewProject': '1',
-            'project_cod': 'VALUE123',
-            'project_registration_and_analysis': '1',
-            'project_location': 'CLIMMOB',
-            'project_unit_of_analysis': '1',
-            'project_label_a': 'PROJECT_LABEL_A',
-            'project_label_b': 'PROJECT_LABEL_B',
-            'project_label_c': 'PROJECT_LABEL_C',
-            'project_numobs': '20',
-            'project_numcom': '20',
-            'project_localvariety': 1,
-            'project_type': 'on',
-            'project_template': 'on',
-            'usingTemplate': 'template1',
-            'project_languages': ['en', 'es'],
-            "testproject": "true"
+            "btn_addNewProject": "1",
+            "project_cod": "VALUE123",
+            "project_registration_and_analysis": "1",
+            "project_location": "CLIMMOB",
+            "project_unit_of_analysis": "1",
+            "project_label_a": "PROJECT_LABEL_A",
+            "project_label_b": "PROJECT_LABEL_B",
+            "project_label_c": "PROJECT_LABEL_C",
+            "project_numobs": "20",
+            "project_numcom": "20",
+            "project_localvariety": 1,
+            "project_type": "on",
+            "project_template": "on",
+            "usingTemplate": "template1",
+            "project_languages": ["en", "es"],
+            "project_objectives": ["obj1"],
         }
 
         mock_get_project_data.return_value = {
-            'project_localvariety': 1,
-            'project_regstatus': 0,
-            'project_numobs': 3,
-            'project_numcom': 2,
-            'project_registration_and_analysis': 1,
-            'project_template_used': '',
-            'project_cod': 'VALUE123',
-            'project_objectives': ['obj1'],
-            'project_languages': ['en'],
-            "testproject": "true"
+            "project_localvariety": 1,
+            "project_regstatus": 0,
+            "project_numobs": 3,
+            "project_numcom": 2,
+            "project_registration_and_analysis": 1,
+            "project_template_used": "",
+            "project_cod": "VALUE123",
+            "project_objectives": ["obj1"],
+            "project_languages": ["en"],
         }
 
-        self.view.getPostDict = MagicMock(return_value={
-            'project_cod': 'VALUE123',
-            'project_registration_and_analysis': '1',
-            'project_location': 'CLIMMOB',
-            'project_unit_of_analysis': '1',
-            'project_label_a': 'Label A',
-            'project_label_b': 'Label B',
-            'project_label_c': 'Label C',
-            'project_numobs': '3',
-            'project_numcom': '2',
-            'project_localvariety': '1',
-            'project_type': 'on',
-            'project_template': 'on',
-            'usingTemplate': 'template1',  # <-- Cambiado aquí
-            'project_languages': ['en'],
-            'project_objectives': ['obj1'],
-            "testproject": "true"
-        })
+        self.view.getPostDict = MagicMock(
+            return_value={
+                "project_cod": "VALUE123",
+                "project_registration_and_analysis": "1",
+                "project_location": "CLIMMOB",
+                "project_unit_of_analysis": "1",
+                "project_label_a": "PROJECT_LABEL_A",
+                "project_label_b": "PROJECT_LABEL_B",
+                "project_label_c": "PROJECT_LABEL_C",
+                "project_numobs": "20",
+                "project_numcom": "20",
+                "project_localvariety": "1",
+                "project_type": "on",
+                "project_template": "on",
+                "usingTemplate": "template1",
+                "project_languages": ["en", "es"],
+                "project_objectives": ["obj1"],
+            }
+        )
 
         mock_get_location_unit_of_analysis_by_combination.return_value = {
-            "pluoa_id":2,
-            "plocation_id":1,
+            "pluoa_id": 2,
+            "plocation_id": 1,
             "puoa_id": 2,
             "registration_and_analysis": 12,
-
         }
 
         mock_get_location_unit_of_analysis_objectives_by_combination.return_value = {
-            "pluoaobj_id":2,
+            "pluoaobj_id": 2,
             "pluoa_id": 2,
             "pobjective_id": 1,
-
         }
         result = self.view.processView()
 
         self.assertIsInstance(result, HTTPFound)
         mock_get_the_project_id_for_owner.assert_called_with(
-            self.view.user.login, 'testproject', self.view.request
+            self.view.user.login, "testproject", self.view.request
         )
         assert mock_get_project_data.call_count >= 2
 
         mock_get_location_unit_of_analysis_by_combination.assert_called_once_with(
-            self.view.request, 'CLIMMOB', '1'
+            self.view.request, "CLIMMOB", "1"
         )
 
         mock_modify_project.assert_called_once()
         mock_modify_project.assert_called_with(1, ANY, self.view.request)
-        mock_delete_all_project_location_unit_objective.assert_called_once_with(1, self.view.request)
+        mock_delete_all_project_location_unit_objective.assert_called_once_with(
+            1, self.view.request
+        )
         mock_get_location_unit_of_analysis_objectives_by_combination.assert_called()
         mock_add_project_location_unit_objective.assert_called()
         mock_delete_all_frj_lang.assert_called_once_with(1, self.view.request)
@@ -346,7 +416,5 @@ class TestModifyProjectView(BaseViewTestCase):
         mock_function_create_clone.assert_called_once()
 
 
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/climmob/views/Api/projectCreation.py
+++ b/climmob/views/Api/projectCreation.py
@@ -40,7 +40,7 @@ from climmob.processes import (
     delete_all_project_location_unit_objective,
 )
 from climmob.views.classes import apiView
-from climmob.views.project import functionCreateClone
+from climmob.views.project import function_create_clone
 
 
 class ReadListOfTemplatesView(apiView):
@@ -649,7 +649,7 @@ class CreateProjectView(apiView):
                                                             assess["ass_cod"]
                                                         )
 
-                                                    ok = functionCreateClone(
+                                                    ok = function_create_clone(
                                                         self,
                                                         projectId,
                                                         idormessage,
@@ -689,7 +689,7 @@ class CreateProjectView(apiView):
                                                         )
                                                     )
 
-                                                    functionCreateClone(
+                                                    function_create_clone(
                                                         self,
                                                         dataworking["usingTemplate"],
                                                         newProjectId,
@@ -1211,7 +1211,7 @@ class updateProject_view(apiView):
                                             self.request,
                                         )
 
-                                        functionCreateClone(
+                                        function_create_clone(
                                             self,
                                             dataworking["usingTemplate"],
                                             newProjectId,

--- a/climmob/views/cloneProjects/cloneProjects.py
+++ b/climmob/views/cloneProjects/cloneProjects.py
@@ -92,7 +92,7 @@ class CloneProjectsView(privateView):
         if stage == 2:
             dataworking["slt_project_by_owner"] = userOwner + "___" + projectCod
 
-            dataworking["projectBeingCloned"] = getAllInformationForProject(
+            dataworking["projectBeingCloned"] = get_all_information_for_project(
                 self, userOwner, projectId
             )
 
@@ -194,7 +194,7 @@ class CloneProjectsView(privateView):
             except:
                 raise HTTPNotFound()
 
-            dataworking["clonedProject"] = getAllInformationForProject(
+            dataworking["clonedProject"] = get_all_information_for_project(
                 self, userOwner, projectId
             )
 
@@ -202,7 +202,7 @@ class CloneProjectsView(privateView):
                 self.user.login, cloned, self.request
             )
 
-            dataworking["projectBeingCloned"] = getAllInformationForProject(
+            dataworking["projectBeingCloned"] = get_all_information_for_project(
                 self, self.user.login, newProjectId
             )
 
@@ -213,7 +213,7 @@ class CloneProjectsView(privateView):
             }
 
 
-def getAllInformationForProject(self, userOwner, projectId):
+def get_all_information_for_project(self, userOwner, projectId):
 
     dataworking = getProjectData(projectId, self.request)
 

--- a/climmob/views/cloneProjects/cloneProjects.py
+++ b/climmob/views/cloneProjects/cloneProjects.py
@@ -21,7 +21,7 @@ from climmob.processes import (
     get_all_affiliations,
 )
 from climmob.views.classes import privateView
-from climmob.views.project import createProjectFunction, functionCreateClone
+from climmob.views.project import create_project_function, function_create_clone
 from climmob.views.registry import getDataFormPreview
 
 
@@ -121,7 +121,7 @@ class cloneProjects_view(privateView):
 
                 if "btn_addNewProject" in self.request.POST:
 
-                    dataworking, error_summary, added = createProjectFunction(
+                    dataworking, error_summary, added = create_project_function(
                         dataworking, error_summary, self
                     )
                     if added:
@@ -130,7 +130,7 @@ class cloneProjects_view(privateView):
                             self.user.login, dataworking["project_cod"], self.request
                         )
 
-                        ok = functionCreateClone(
+                        ok = function_create_clone(
                             self,
                             projectId,
                             newProjectId,

--- a/climmob/views/cloneProjects/cloneProjects.py
+++ b/climmob/views/cloneProjects/cloneProjects.py
@@ -18,6 +18,7 @@ from climmob.processes import (
     get_all_project_location,
     get_all_unit_of_analysis_by_location,
     get_all_objectives_by_location_and_unit_of_analysis,
+    get_all_affiliations,
 )
 from climmob.views.classes import privateView
 from climmob.views.project import createProjectFunction, functionCreateClone
@@ -178,6 +179,7 @@ class cloneProjects_view(privateView):
                     dataworking["project_location"],
                     dataworking["project_unit_of_analysis"],
                 ),
+                "list_of_affiliation": get_all_affiliations(self.request),
             }
 
         if stage == 4:

--- a/climmob/views/cloneProjects/cloneProjects.py
+++ b/climmob/views/cloneProjects/cloneProjects.py
@@ -25,7 +25,7 @@ from climmob.views.project import create_project_function, function_create_clone
 from climmob.views.registry import getDataFormPreview
 
 
-class cloneProjects_view(privateView):
+class CloneProjectsView(privateView):
     def processView(self):
 
         if self.request.registry.settings.get("projects.limit", "false") == "true":
@@ -95,8 +95,6 @@ class cloneProjects_view(privateView):
             dataworking["projectBeingCloned"] = getAllInformationForProject(
                 self, userOwner, projectId
             )
-
-            # print(dataworking["projectBeingCloned"])
 
             return {
                 "activeProject": getActiveProject(self.user.login, self.request),

--- a/climmob/views/project.py
+++ b/climmob/views/project.py
@@ -57,7 +57,7 @@ from climmob.views.classes import privateView
 from climmob.views.validators.ProjectExistsValidator import ProjectExistsValidator
 
 
-class getTemplatesByTypeOfProject_view(privateView):
+class GetTemplatesByTypeOfProjectView(privateView):
     def processView(self):
         if self.request.method == "GET":
             typeId = self.request.matchdict["typeid"]
@@ -69,7 +69,7 @@ class getTemplatesByTypeOfProject_view(privateView):
         raise HTTPNotFound
 
 
-class projectList_view(privateView):
+class ProjectListView(privateView):
     def processView(self):
 
         return {
@@ -80,7 +80,7 @@ class projectList_view(privateView):
         }
 
 
-class newProject_view(privateView):
+class NewProjectView(privateView):
     def processView(self):
 
         if self.request.registry.settings.get("projects.limit", "false") == "true":
@@ -116,7 +116,7 @@ class newProject_view(privateView):
             if "btn_addNewProject" in self.request.POST:
                 dataworking = self.getPostDict()
 
-                dataworking, error_summary, added = createProjectFunction(
+                dataworking, error_summary, added = create_project_function(
                     dataworking, error_summary, self
                 )
                 if added:
@@ -162,7 +162,7 @@ class newProject_view(privateView):
         }
 
 
-def createProjectFunction(dataworking, error_summary, self):
+def create_project_function(dataworking, error_summary, self):
     added = False
     dataworking["user_name"] = self.user.login
     dataworking["project_regstatus"] = 0
@@ -313,7 +313,7 @@ def createProjectFunction(dataworking, error_summary, self):
                                         self.request,
                                     )
 
-                                    functionCreateClone(
+                                    function_create_clone(
                                         self,
                                         dataworking["usingTemplate"],
                                         newProjectId,
@@ -352,7 +352,7 @@ def createProjectFunction(dataworking, error_summary, self):
     return dataworking, error_summary, added
 
 
-def functionCreateClone(self, projectId, newProjectId, structureToBeCloned):
+def function_create_clone(self, projectId, newProjectId, structureToBeCloned):
 
     if "fieldagents" in structureToBeCloned:
         enumerators = getProjectEnumerators(
@@ -490,7 +490,7 @@ def functionCreateClone(self, projectId, newProjectId, structureToBeCloned):
     return ""
 
 
-class modifyProject_view(privateView):
+class ModifyProjectView(privateView):
     validators = (ProjectExistsValidator,)
 
     def processView(self):
@@ -716,7 +716,7 @@ class modifyProject_view(privateView):
                                             self.request,
                                         )
 
-                                        functionCreateClone(
+                                        function_create_clone(
                                             self,
                                             data["usingTemplate"],
                                             newProjectId,
@@ -768,7 +768,7 @@ class modifyProject_view(privateView):
         return context
 
 
-class deleteProject_view(privateView):
+class DeleteProjectView(privateView):
     validators = (ProjectExistsValidator,)
 
     def processView(self):
@@ -816,7 +816,7 @@ class deleteProject_view(privateView):
         }
 
 
-class CurationOfProjects_view(privateView):
+class CurationOfProjectsView(privateView):
     def processView(self):
         error_summary = {}
 

--- a/climmob/views/project.py
+++ b/climmob/views/project.py
@@ -51,6 +51,7 @@ from climmob.processes import (
     get_location_unit_of_analysis_by_combination,
     get_location_unit_of_analysis_objectives_by_combination,
     delete_all_project_location_unit_objective,
+    get_all_affiliations,
 )
 from climmob.views.classes import privateView
 from climmob.views.validators.ProjectExistsValidator import ProjectExistsValidator
@@ -157,6 +158,7 @@ class newProject_view(privateView):
                 dataworking["project_location"],
                 dataworking["project_unit_of_analysis"],
             ),
+            "list_of_affiliation": get_all_affiliations(self.request),
         }
 
 
@@ -759,6 +761,7 @@ class modifyProject_view(privateView):
             "listOfObjectives": get_all_objectives_by_location_and_unit_of_analysis(
                 self.request, data["project_location"], data["project_unit_of_analysis"]
             ),
+            "list_of_affiliation": get_all_affiliations(self.request),
         }
         for plugin in p.PluginImplementations(p.IProject):
             context = plugin.before_returning_project_context(self.request, context)


### PR DESCRIPTION
issue #358 
Reorder the data of affiliation bring it alphabetic order,
rewrite the list drop down to show and select all the list on db, allow to user create and select a new affiliation on the project (no data base),
keep the security parameter of required data, doesn't allow the option by default
and bring the consult tothe 3 options that need it (new, edit and clone)