### PR TITLE
Keept the language trial documentation

### DIFF
--- a/climmob/config/routes.py
+++ b/climmob/config/routes.py
@@ -289,7 +289,7 @@ from climmob.views.extra_form import ExtraFormPostView
 
 from climmob.views.project_metadata import (
     ProjectMetadataFormView,
-    ShowMetadataForm_view,
+    ShowMetadataFormView,
 )
 
 # -------Api-------#
@@ -1292,7 +1292,7 @@ def loadRoutes(config):
         addRoute(
             "ShowMetadataForm",
             "/user/{user}/project/{project}/metadataform/{metadataform}/ShowMetadata",
-            ShowMetadataForm_view,
+            ShowMetadataFormView,
             "string",
         )
     )

--- a/climmob/config/routes.py
+++ b/climmob/config/routes.py
@@ -288,7 +288,7 @@ from climmob.views.projectsSummary.projectsSummary import (
 from climmob.views.extra_form import ExtraFormPostView
 
 from climmob.views.project_metadata import (
-    ProjectMetadataForm_view,
+    ProjectMetadataFormView,
     ShowMetadataForm_view,
 )
 
@@ -1283,7 +1283,7 @@ def loadRoutes(config):
         addRoute(
             "Metadata",
             "/user/{user}/project/{project}/metadata",
-            ProjectMetadataForm_view,
+            ProjectMetadataFormView,
             "project/metadata/metadata.jinja2",
         )
     )

--- a/climmob/models/climmobv4.py
+++ b/climmob/models/climmobv4.py
@@ -1407,6 +1407,7 @@ class ProjectMetadataForm(Base):
         nullable=False,
     )
     pmf_json = Column(JSON, nullable=False)
+    pmf_lang = Column(ForeignKey("i18n.lang_code"), nullable=True)
 
     Project = relationship("Project")
     MetadataForm = relationship("MetadataForm", backref="project_metadata_form")

--- a/climmob/models/climmobv4.py
+++ b/climmob/models/climmobv4.py
@@ -1408,6 +1408,7 @@ class ProjectMetadataForm(Base):
     )
     pmf_json = Column(JSON, nullable=False)
     pmf_lang = Column(ForeignKey("i18n.lang_code"), nullable=True)
+    pmf_last_update = Column(DateTime, nullable=True)
 
     Project = relationship("Project")
     MetadataForm = relationship("MetadataForm", backref="project_metadata_form")

--- a/climmob/templates/project/metadata/metadata.jinja2
+++ b/climmob/templates/project/metadata/metadata.jinja2
@@ -111,9 +111,9 @@
                 </div>
                 <div class="ibox-content">
 
-                    <h2>
-                        {{ _("Please note that all fields are mandatory unless they include the label “(Optional)” ") }}.
-                    </h2>
+{#                    <h2>#}
+{#                        {{ _("Please note that all fields are mandatory unless they include the label “(Optional)” ") }}.#}
+{#                    </h2>#}
                     <br>
 
                     <form class="form-horizontal" id="form_metadata" role="form" method="post" action="{{ request.url }}" >

--- a/climmob/templates/snippets/project/metadata/metadataForm.jinja2
+++ b/climmob/templates/snippets/project/metadata/metadataForm.jinja2
@@ -1,3 +1,11 @@
+<h3>
+    {% if lang_answer_name %}
+        {{_("This form displays the answers in the language they were saved in:")}} {{ lang_answer_name }}
+    {% else %}
+        {{ _("Please check your selected language. Your answers will be saved and displayed in that language. To ensure consistency, use the same language across all metadata fields and match the language chosen for the project.") }}
+    {% endif %}
+</h3>
+<br>
 {% if form_to_use == 1 %}
     {% include template_table %}
 {% else %}

--- a/climmob/templates/snippets/project/metadata/metadata_inputs.jinja2
+++ b/climmob/templates/snippets/project/metadata/metadata_inputs.jinja2
@@ -31,7 +31,22 @@
 
 {% elif JsonInfo["type"] == "select all that apply" %}
 
-    <select data-placeholder="" name="{{ JsonInfo["name"] }}" data-dropdown-id="select_all#{{ JsonInfo["name"] }}" class="chosen-select form-control" multiple tabindex="1" {% if "bind" in JsonInfo.keys() and "required" in JsonInfo["bind"] and JsonInfo["bind"]["required"] == "yes" %} required="" {% endif %} oninvalid="this.setCustomValidity('{% if "bind" in JsonInfo.keys() and "jr:requiredMsg" in JsonInfo["bind"].keys() %}{{ JsonInfo["bind"]["jr:requiredMsg"][request.locale_name].replace("'"," ") }}{% endif %}')" onchange="this.setCustomValidity('')" {% if onlySee %} disabled {% endif %} {% if "allow_changes" in JsonInfo.keys() and JsonInfo["allow_changes"] == "no" %} disabled {% endif %}>
+    <select data-placeholder="" name="{{ JsonInfo["name"] }}" data-dropdown-id="select_all#{{ JsonInfo["name"] }}"
+            class="chosen-select form-control" multiple tabindex="1"
+            {% if "bind" in JsonInfo.keys() and "required" in JsonInfo["bind"] and JsonInfo["bind"]["required"] == "yes" %}
+            required=""
+            {% endif %}
+            oninvalid="this.setCustomValidity(
+                '{% if "bind" in JsonInfo.keys() and "jr:requiredMsg" in JsonInfo["bind"].keys() %}{{
+                    JsonInfo["bind"]["jr:requiredMsg"][request.locale_name].replace("'"," ") }}{% endif %}')"
+            onchange="this.setCustomValidity('')"
+            {% if onlySee %}
+            disabled
+            {% endif %}
+            {% if "allow_changes" in JsonInfo.keys() and JsonInfo["allow_changes"] == "no" %}
+            disabled
+            {% endif %}>
+
         {% for choice in JsonInfo["choices"] %}
             <option value="{{ choice["label"][lang_answer] }}"
             {% if choice['is_option_other'] == 'yes' %} data-is-other="yes" {% endif %}

--- a/climmob/templates/snippets/project/metadata/metadata_inputs.jinja2
+++ b/climmob/templates/snippets/project/metadata/metadata_inputs.jinja2
@@ -21,9 +21,9 @@
 
         <select data-placeholder="" name="{{ JsonInfo["name"] }}" data-dropdown-id="select_all#{{ JsonInfo["name"] }}" class="chosen-select form-control" {% if "bind" in JsonInfo.keys() and "required" in JsonInfo["bind"] and JsonInfo["bind"]["required"] == "yes" %} required="" {% endif %} oninvalid="this.setCustomValidity('{% if "bind" in JsonInfo.keys() and "jr:requiredMsg" in JsonInfo["bind"].keys() %}{{ JsonInfo["bind"]["jr:requiredMsg"][request.locale_name].replace("'"," ") }}{% endif %}')" onchange="this.setCustomValidity('')" {% if onlySee %} disabled {% endif %} {% if "allow_changes" in JsonInfo.keys() and JsonInfo["allow_changes"] == "no" %} disabled {% endif %}>
             {% for choice in JsonInfo["choices"] %}
-                <option value="{{ choice["label"][request.locale_name] }}"
+                <option value="{{ choice["label"][lang_answer] }}"
                 {% if choice['is_option_other'] == 'yes' %} data-is-other="yes" {% endif %}
-                >{{ choice["label"][request.locale_name] }}</option>
+                >{{ choice["label"][ lang_answer ] }}</option>
             {% endfor %}
         </select>
 
@@ -33,9 +33,9 @@
 
     <select data-placeholder="" name="{{ JsonInfo["name"] }}" data-dropdown-id="select_all#{{ JsonInfo["name"] }}" class="chosen-select form-control" multiple tabindex="1" {% if "bind" in JsonInfo.keys() and "required" in JsonInfo["bind"] and JsonInfo["bind"]["required"] == "yes" %} required="" {% endif %} oninvalid="this.setCustomValidity('{% if "bind" in JsonInfo.keys() and "jr:requiredMsg" in JsonInfo["bind"].keys() %}{{ JsonInfo["bind"]["jr:requiredMsg"][request.locale_name].replace("'"," ") }}{% endif %}')" onchange="this.setCustomValidity('')" {% if onlySee %} disabled {% endif %} {% if "allow_changes" in JsonInfo.keys() and JsonInfo["allow_changes"] == "no" %} disabled {% endif %}>
         {% for choice in JsonInfo["choices"] %}
-            <option value="{{ choice["label"][request.locale_name] }}"
+            <option value="{{ choice["label"][lang_answer] }}"
             {% if choice['is_option_other'] == 'yes' %} data-is-other="yes" {% endif %}
-            >{{ choice["label"][request.locale_name] }} </option>
+            >{{ choice["label"][lang_answer] }} </option>
         {% endfor %}
     </select>
 

--- a/climmob/templates/snippets/project/metadata/template_form.jinja2
+++ b/climmob/templates/snippets/project/metadata/template_form.jinja2
@@ -1,10 +1,4 @@
-<p>
-    {% if lang_answer_name %}
-        {{_("This form show the answers on the same language once saved, it was: ")}} {{ lang_answer_name }}
-    {% else %}
-        {{ _("Please check your language, the answers going to be displayed at same language once save") }}
-    {% endif %}
-</p>
+
     {% if activeProject["access_type"] in [4] %}
         {% set onlySee = True %}
     {% endif %}
@@ -55,7 +49,7 @@
                 <div class="form-group" div-name="div_{{ JsonInfo.get("name", {}) }}">
 
                     <div class="col-sm-12" >
-                        <h3>{{ JsonInfo["label"][request.locale_name] }} </h3>
+                        <h3>{{ JsonInfo["label"][request.locale_name] }}  {% if ("bind" in JsonInfo.keys() and "required" in JsonInfo["bind"].keys() and JsonInfo["bind"]["required"] == "yes") or JsonInfo["name"][-6:] == '_other' %}{% else %}({{ _("Optional") }}){% endif %}</h3>
                         {% if "hint" in JsonInfo.keys() %} <p>{{ JsonInfo["hint"][request.locale_name] }}</p>{% endif %}
 
                         {% include inputs %}
@@ -153,13 +147,12 @@
         methodRecursiveToShowInformation(postData, $("#spaceForPutTheForm"))
     }
 
-    function searchIntoDictionary(name){
-        dictionary = {{ dictionary }}
-        for (const key in dictionary) {
-            if (dictionary[key]["name"] === name)
-                return dictionary[key]["type"]
-        }
-    }
+    {#function searchIntoDictionary(name){#}
+    {#    dictionary = {{ dictionary }}#}
+    {#    for (const key in dictionary) {#}
+    {#        if (dictionary[key]["name"] === name)#}
+    {#            return dictionary[key]["type"]#}
+    {#    }    }#}
 
 
     function methodRecursiveToShowInformation(postData, parentElement) {

--- a/climmob/templates/snippets/project/metadata/template_form.jinja2
+++ b/climmob/templates/snippets/project/metadata/template_form.jinja2
@@ -1,4 +1,10 @@
-
+<p>
+    {% if lang_answer_name %}
+        {{_("This form show the answers on the same language once saved, it was: ")}} {{ lang_answer_name }}
+    {% else %}
+        {{ _("Please check your language, the answers going to be displayed at same language once save") }}
+    {% endif %}
+</p>
     {% if activeProject["access_type"] in [4] %}
         {% set onlySee = True %}
     {% endif %}

--- a/climmob/templates/snippets/project/metadata/template_table.jinja2
+++ b/climmob/templates/snippets/project/metadata/template_table.jinja2
@@ -1,5 +1,3 @@
-<p> {{_("This Table show the questions on the same language once saved, it is: ")}} {{ lang_answer_name }}
-</p>
 
     {% if activeProject["access_type"] in [4] %}
         {% set onlySee = True %}
@@ -177,13 +175,12 @@
         methodRecursiveToShowInformation(postData, $("#spaceForPutTheForm"))
     }
 
-    function searchIntoDictionary(name){
-        dictionary = {{ dictionary }}
-        for (const key in dictionary) {
-            if (dictionary[key]["name"] === name)
-                return dictionary[key]["type"]
-        }
-    }
+    {#function searchIntoDictionary(name){#}
+    {#    dictionary = {{ dictionary }}#}
+    {#    for (const key in dictionary) {#}
+    {#        if (dictionary[key]["name"] === name)#}
+    {#            return dictionary[key]["type"]#}
+    {#    }    }#}
 
 
     function methodRecursiveToShowInformation(postData, parentElement) {

--- a/climmob/templates/snippets/project/metadata/template_table.jinja2
+++ b/climmob/templates/snippets/project/metadata/template_table.jinja2
@@ -1,3 +1,5 @@
+<p> {{_("This Table show the questions on the same language once saved, it is: ")}} {{ lang_answer_name }}
+</p>
 
     {% if activeProject["access_type"] in [4] %}
         {% set onlySee = True %}

--- a/climmob/tests/test_utils/test_views_project_metadata.py
+++ b/climmob/tests/test_utils/test_views_project_metadata.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import patch
+
+from climmob.tests.test_utils.common import ViewBaseTest
+from climmob.views.project_metadata import (
+ProjectMetadataFormView,
+)
+
+class TestProjectMetadataFormView(ViewBaseTest):
+    view = ProjectMetadataFormView
+    request_method = "POST"
+
+
+    @patch("climmob.views.project_metadata.getMetadataForm", return_value=None)
+    def test_project_metadata_form_view_no_metadata(self):
+
+        self.view.project = "Test Project"
+        self.view.metadataForm = None
+
+

--- a/climmob/tests/test_utils/test_views_project_metadata.py
+++ b/climmob/tests/test_utils/test_views_project_metadata.py
@@ -1,20 +1,494 @@
-import unittest
+import datetime as real_datetime
 from unittest.mock import patch
 
+from pyramid.httpexceptions import HTTPNotFound, HTTPFound
+
 from climmob.tests.test_utils.common import ViewBaseTest
-from climmob.views.project_metadata import (
-ProjectMetadataFormView,
-)
+from climmob.views.project_metadata import ProjectMetadataFormView, ShowMetadataFormView
+
 
 class TestProjectMetadataFormView(ViewBaseTest):
-    view = ProjectMetadataFormView
+    view_class = ProjectMetadataFormView
     request_method = "POST"
 
+    def setUp(self):
+        super().setUp()
+        self.view.request.matchdict = {"project": "Test_Project", "user": "test_user"}
+        self.view.request.params = {"metadataForm": {"data1": "data1"}}
+        self.view.request.POST = {
+            "btn_save_metadata": 1,
+            "_jsonResult": '{"some": "data3"}',
+            "metadata_id": 3,
+        }
 
+    @patch("climmob.views.project_metadata.projectExists", return_value=False)
+    @patch("climmob.views.project_metadata.getActiveProject", return_value=1)
+    def test_process_view_project_metadata_form_view_no_metadata_no_project_exist(
+        self, mock_get_active_project, mock_project_exists
+    ):
+        self.view.request.params = {}
+        with self.assertRaises(HTTPNotFound):
+            self.view.processView()
+        mock_get_active_project.assert_called_once_with("test_user", self.view.request)
+        mock_project_exists.assert_called_once_with(
+            "test_user", "test_user", "Test_Project", self.view.request
+        )
+
+    @patch(
+        "climmob.views.project_metadata.getMetadataForProject",
+        return_value={"Data2": "data2"},
+    )
+    @patch("climmob.views.project_metadata.getTheProjectIdForOwner", return_value=2)
+    @patch("climmob.views.project_metadata.projectExists", return_value=True)
+    @patch("climmob.views.project_metadata.getActiveProject", return_value=1)
     @patch("climmob.views.project_metadata.getMetadataForm", return_value=None)
-    def test_project_metadata_form_view_no_metadata(self):
+    def test_process_view_project_metadata_form_view_no_post(
+        self,
+        mock_get_metadata_form,
+        mock_get_active_project,
+        mock_project_exists,
+        mock_get_the_project_id_for_owner,
+        mock_get_metadata_for_project,
+    ):
+        self.view.request.method = "GET"
+        response = self.view.processView()
+        self.assertEqual(
+            response,
+            {
+                "activeProject": 1,
+                "dataworking": {},
+                "metadataForm": None,
+                "listOfProjectMetadata": {"Data2": "data2"},
+            },
+        )
+        mock_get_metadata_form.assert_called_once_with(
+            self.view.request, {"data1": "data1"}
+        )
+        mock_get_active_project.assert_called_once_with("test_user", self.view.request)
+        mock_project_exists.assert_called_once_with(
+            "test_user", "test_user", "Test_Project", self.view.request
+        )
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "test_user", "Test_Project", self.view.request
+        )
+        mock_get_metadata_for_project.assert_called_once_with(self.view.request, 2)
 
-        self.view.project = "Test Project"
-        self.view.metadataForm = None
+    @patch(
+        "climmob.views.project_metadata.modifyProjectMetadataForm",
+        return_value=(True, ""),
+    )
+    @patch(
+        "climmob.views.project_metadata.getProjectMetadataForm",
+        return_value={"data4": "data4"},
+    )
+    @patch(
+        "climmob.views.project_metadata.getMetadataForProject",
+        return_value={"Data2": "data2"},
+    )
+    @patch("climmob.views.project_metadata.getTheProjectIdForOwner", return_value=2)
+    @patch("climmob.views.project_metadata.projectExists", return_value=True)
+    @patch("climmob.views.project_metadata.getActiveProject", return_value=1)
+    @patch("climmob.views.project_metadata.getMetadataForm", return_value=None)
+    def test_process_view_project_metadata_form_view_edited(
+        self,
+        mock_get_metadata_form,
+        mock_get_active_project,
+        mock_project_exists,
+        mock_get_the_project_id_for_owner,
+        mock_get_metadata_for_project,
+        mock_get_project_metadata_form,
+        mock_modify_project_metadata_form,
+    ):
+        response = self.view.processView()
+        self.assertIsInstance(response, HTTPFound)
+        mock_get_metadata_form.assert_called_once_with(
+            self.view.request, {"data1": "data1"}
+        )
+        mock_get_active_project.assert_called_once_with("test_user", self.view.request)
+        mock_project_exists.assert_called_once_with(
+            "test_user", "test_user", "Test_Project", self.view.request
+        )
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "test_user", "Test_Project", self.view.request
+        )
+        mock_get_metadata_for_project.assert_called_once_with(self.view.request, 2)
+        mock_get_project_metadata_form.assert_called_once_with(self.view.request, 2, 3)
+        mock_modify_project_metadata_form.assert_called_once_with(
+            self.view.request,
+            2,
+            3,
+            {
+                "btn_save_metadata": 1,
+                "_jsonResult": '{"some": "data3"}',
+                "metadata_id": 3,
+                "project_id": 2,
+                "pmf_json": {"some": "data3"},
+            },
+        )
+
+    @patch("climmob.views.project_metadata.datetime")
+    @patch(
+        "climmob.views.project_metadata.addProjectMetadataForm", return_value=(True, "")
+    )
+    @patch("climmob.views.project_metadata.getProjectMetadataForm", return_value={})
+    @patch(
+        "climmob.views.project_metadata.getMetadataForProject",
+        return_value={"Data2": "data2"},
+    )
+    @patch("climmob.views.project_metadata.getTheProjectIdForOwner", return_value=2)
+    @patch("climmob.views.project_metadata.projectExists", return_value=True)
+    @patch("climmob.views.project_metadata.getActiveProject", return_value=1)
+    @patch("climmob.views.project_metadata.getMetadataForm", return_value=None)
+    def test_process_view_project_metadata_form_view_added(
+        self,
+        mock_get_metadata_form,
+        mock_get_active_project,
+        mock_project_exists,
+        mock_get_the_project_id_for_owner,
+        mock_get_metadata_for_project,
+        mock_get_project_metadata_form,
+        mock_add_project_metadata_form,
+        mock_datetime,
+    ):
+        fixed_time = real_datetime.datetime(2024, 1, 1, 12, 0, 0)
+        mock_datetime.now.return_value = fixed_time
+        mock_datetime.side_effect = lambda *args, **kwargs: real_datetime.datetime(
+            *args, **kwargs
+        )
+        self.view.request.locale_name = "en"
+        response = self.view.processView()
+        self.assertIsInstance(response, HTTPFound)
+        mock_get_metadata_form.assert_called_once_with(
+            self.view.request, {"data1": "data1"}
+        )
+        mock_get_active_project.assert_called_once_with("test_user", self.view.request)
+        mock_project_exists.assert_called_once_with(
+            "test_user", "test_user", "Test_Project", self.view.request
+        )
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "test_user", "Test_Project", self.view.request
+        )
+        mock_get_metadata_for_project.assert_called_once_with(self.view.request, 2)
+        mock_get_project_metadata_form.assert_called_once_with(self.view.request, 2, 3)
+        mock_add_project_metadata_form.assert_called_once_with(
+            {
+                "btn_save_metadata": 1,
+                "_jsonResult": '{"some": "data3"}',
+                "metadata_id": 3,
+                "project_id": 2,
+                "pmf_json": {"some": "data3"},
+                "pmf_last_update": fixed_time,
+                "pmf_lang": "en",
+            },
+            self.view.request,
+        )
+
+    @patch("climmob.views.project_metadata.datetime")
+    @patch(
+        "climmob.views.project_metadata.modifyProjectMetadataForm",
+        return_value=(True, ""),
+    )
+    @patch(
+        "climmob.views.project_metadata.getProjectMetadataForm",
+        return_value={"data4": "data4"},
+    )
+    @patch(
+        "climmob.views.project_metadata.getMetadataForProject",
+        return_value={"Data2": "data2"},
+    )
+    @patch("climmob.views.project_metadata.getTheProjectIdForOwner", return_value=2)
+    @patch("climmob.views.project_metadata.projectExists", return_value=True)
+    @patch("climmob.views.project_metadata.getActiveProject", return_value=1)
+    @patch("climmob.views.project_metadata.getMetadataForm", return_value=None)
+    def test_process_view_project_metadata_form_view_edited(
+        self,
+        mock_get_metadata_form,
+        mock_get_active_project,
+        mock_project_exists,
+        mock_get_the_project_id_for_owner,
+        mock_get_metadata_for_project,
+        mock_get_project_metadata_form,
+        mock_modify_project_metadata_form,
+        mock_datetime,
+    ):
+        fixed_time = real_datetime.datetime(2024, 1, 1, 12, 0, 0)
+        mock_datetime.now.return_value = fixed_time
+        mock_datetime.side_effect = lambda *args, **kwargs: real_datetime.datetime(
+            *args, **kwargs
+        )
+
+        response = self.view.processView()
+        self.assertIsInstance(response, HTTPFound)
+        mock_get_metadata_form.assert_called_once_with(
+            self.view.request, {"data1": "data1"}
+        )
+        mock_get_active_project.assert_called_once_with("test_user", self.view.request)
+        mock_project_exists.assert_called_once_with(
+            "test_user", "test_user", "Test_Project", self.view.request
+        )
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "test_user", "Test_Project", self.view.request
+        )
+        mock_get_metadata_for_project.assert_called_once_with(self.view.request, 2)
+        mock_get_project_metadata_form.assert_called_once_with(self.view.request, 2, 3)
+        mock_modify_project_metadata_form.assert_called_once_with(
+            self.view.request,
+            2,
+            3,
+            {
+                "btn_save_metadata": 1,
+                "_jsonResult": '{"some": "data3"}',
+                "metadata_id": 3,
+                "project_id": 2,
+                "pmf_json": {"some": "data3"},
+                "pmf_last_update": fixed_time,
+            },
+        )
+
+    @patch("climmob.views.project_metadata.datetime")
+    @patch(
+        "climmob.views.project_metadata.addProjectMetadataForm",
+        return_value=(False, "Error to add"),
+    )
+    @patch("climmob.views.project_metadata.getProjectMetadataForm", return_value={})
+    @patch(
+        "climmob.views.project_metadata.getMetadataForProject",
+        return_value={"Data2": "data2"},
+    )
+    @patch("climmob.views.project_metadata.getTheProjectIdForOwner", return_value=2)
+    @patch("climmob.views.project_metadata.projectExists", return_value=True)
+    @patch("climmob.views.project_metadata.getActiveProject", return_value=1)
+    @patch("climmob.views.project_metadata.getMetadataForm", return_value=None)
+    def test_process_view_project_metadata_form_view_added_failure(
+        self,
+        mock_get_metadata_form,
+        mock_get_active_project,
+        mock_project_exists,
+        mock_get_the_project_id_for_owner,
+        mock_get_metadata_for_project,
+        mock_get_project_metadata_form,
+        mock_add_project_metadata_form,
+        mock_datetime,
+    ):
+        fixed_time = real_datetime.datetime(2024, 1, 1, 12, 0, 0)
+        mock_datetime.now.return_value = fixed_time
+        mock_datetime.side_effect = lambda *args, **kwargs: real_datetime.datetime(
+            *args, **kwargs
+        )
+
+        self.view.request.locale_name = "en"
+        response = self.view.processView()
+        self.assertEqual(
+            response,
+            {
+                "activeProject": 1,
+                "dataworking": {},
+                "metadataForm": None,
+                "listOfProjectMetadata": {"Data2": "data2"},
+            },
+        )
+        mock_get_metadata_form.assert_called_once_with(
+            self.view.request, {"data1": "data1"}
+        )
+        mock_get_active_project.assert_called_once_with("test_user", self.view.request)
+        mock_project_exists.assert_called_once_with(
+            "test_user", "test_user", "Test_Project", self.view.request
+        )
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "test_user", "Test_Project", self.view.request
+        )
+        mock_get_metadata_for_project.assert_called_once_with(self.view.request, 2)
+        mock_get_project_metadata_form.assert_called_once_with(self.view.request, 2, 3)
+        mock_add_project_metadata_form.assert_called_once_with(
+            {
+                "btn_save_metadata": 1,
+                "_jsonResult": '{"some": "data3"}',
+                "metadata_id": 3,
+                "project_id": 2,
+                "pmf_json": {"some": "data3"},
+                "pmf_last_update": fixed_time,
+                "pmf_lang": "en",
+            },
+            self.view.request,
+        )
 
 
+class TestShowMetadataFormView(ViewBaseTest):
+    view_class = ShowMetadataFormView
+
+    def setUp(self):
+        super().setUp()
+        self.view.request.matchdict = {
+            "project": "Test_Project",
+            "user": "test_user",
+            "metadataform": "data1",
+        }
+        self.view.request.locale_name = "en"
+
+    def test_process_view_show_project_metadata_form_view_no_get(self):
+        self.view.request.method = "POST"
+        response = self.view.processView()
+        self.assertEqual(response, "")
+
+    @patch("climmob.views.project_metadata.projectExists", return_value=False)
+    def test_process_view_show_project_metadata_form_view_no_project_exists(
+        self, mock_project_exists
+    ):
+        response = self.view.processView()
+        self.assertEqual(response, "")
+        mock_project_exists.assert_called_once_with(
+            "test_user", "test_user", "Test_Project", self.view.request
+        )
+
+    @patch("climmob.views.project_metadata.getMetadataForm", return_value={})
+    @patch("climmob.views.project_metadata.getTheProjectIdForOwner", return_value=1)
+    @patch("climmob.views.project_metadata.projectExists", return_value=True)
+    def test_process_view_show_project_metadata_form_view_no_metadata_form(
+        self,
+        mock_project_exists,
+        mock_get_the_project_id_for_owner,
+        mock_get_metadata_form,
+    ):
+        response = self.view.processView()
+        self.assertEqual(response, "")
+        mock_project_exists.assert_called_once_with(
+            "test_user", "test_user", "Test_Project", self.view.request
+        )
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "test_user", "Test_Project", self.view.request
+        )
+        mock_get_metadata_form.assert_called_once_with(self.view.request, "data1")
+
+    @patch(
+        "climmob.views.project_metadata.get_all_affiliations",
+        return_value={"data8", "data8"},
+    )
+    @patch(
+        "climmob.views.project_metadata.getActiveProject",
+        return_value={"data7": "data7"},
+    )
+    @patch(
+        "climmob.views.project_metadata.getCombinations",
+        return_value=(
+            {},
+            {},
+            [
+                {"tech_id": 1, "alias_id": 2, "alias_name": "test"},
+                {"tech_id": 3, "alias_id": 4, "alias_name": "test2"},
+            ],
+        ),
+    )
+    @patch(
+        "climmob.views.project_metadata.languageByLanguageCode",
+        return_value={"lang_code": "es", "lang_name": "Español"},
+    )
+    @patch(
+        "climmob.views.project_metadata.getProjectMetadataForm",
+        return_value={
+            "data": "data3",
+            "pmf_lang": "es",
+            "pmf_json": {"data6": "data6"},
+        },
+    )
+    @patch(
+        "climmob.views.project_metadata.getMetadataForm",
+        return_value={
+            "data2": "data2",
+            "metadata_for_technology_options": 1,
+            "metadata_json": '{"data7":"data7"}',
+            "metadata_name": "name",
+        },
+    )
+    @patch("climmob.views.project_metadata.getTheProjectIdForOwner", return_value=1)
+    @patch("climmob.views.project_metadata.projectExists", return_value=True)
+    def test_process_view_show_project_metadata_form_view_success(
+        self,
+        mock_project_exists,
+        mock_get_the_project_id_for_owner,
+        mock_get_metadata_form,
+        mock_get_project_metadata_form,
+        mock_language_by_language_code,
+        mock_get_combinations,
+        mock_get_active_project,
+        mock_get_all_affiliations,
+    ):
+        response = self.view.processView()
+        mock_project_exists.assert_called_once_with(
+            "test_user", "test_user", "Test_Project", self.view.request
+        )
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "test_user", "Test_Project", self.view.request
+        )
+        mock_get_metadata_form.assert_called_once_with(self.view.request, "data1")
+        mock_get_project_metadata_form.assert_called_once_with(
+            self.view.request, 1, "data1"
+        )
+        mock_language_by_language_code.assert_called_once_with("es", self.view.request)
+        mock_get_combinations.assert_called_once_with(1, self.view.request)
+        mock_get_active_project.assert_called_once_with("test_user", self.view.request)
+        mock_get_all_affiliations.assert_called_once_with(self.view.request)
+
+    @patch(
+        "climmob.views.project_metadata.get_all_affiliations",
+        return_value={"data8", "data8"},
+    )
+    @patch(
+        "climmob.views.project_metadata.getActiveProject",
+        return_value={"data7": "data7"},
+    )
+    @patch(
+        "climmob.views.project_metadata.getCombinations",
+        return_value=(
+            {},
+            {},
+            [
+                {"tech_id": 1, "alias_id": 2, "alias_name": "test"},
+                {"tech_id": 3, "alias_id": 4, "alias_name": "test2"},
+            ],
+        ),
+    )
+    @patch(
+        "climmob.views.project_metadata.languageByLanguageCode",
+        return_value={"lang_code": "es", "lang_name": "Español"},
+    )
+    @patch(
+        "climmob.views.project_metadata.getProjectMetadataForm",
+        return_value={"data": "data3", "pmf_lang": "es", "pmf_json": {}},
+    )
+    @patch(
+        "climmob.views.project_metadata.getMetadataForm",
+        return_value={
+            "data2": "data2",
+            "metadata_for_technology_options": 1,
+            "metadata_json": '{"data7":"data7"}',
+            "metadata_name": "name",
+        },
+    )
+    @patch("climmob.views.project_metadata.getTheProjectIdForOwner", return_value=1)
+    @patch("climmob.views.project_metadata.projectExists", return_value=True)
+    def test_process_view_show_project_metadata_form_view_success_no_information_filled(
+        self,
+        mock_project_exists,
+        mock_get_the_project_id_for_owner,
+        mock_get_metadata_form,
+        mock_get_project_metadata_form,
+        mock_language_by_language_code,
+        mock_get_combinations,
+        mock_get_active_project,
+        mock_get_all_affiliations,
+    ):
+        response = self.view.processView()
+        mock_project_exists.assert_called_once_with(
+            "test_user", "test_user", "Test_Project", self.view.request
+        )
+        mock_get_the_project_id_for_owner.assert_called_once_with(
+            "test_user", "Test_Project", self.view.request
+        )
+        mock_get_metadata_form.assert_called_once_with(self.view.request, "data1")
+        mock_get_project_metadata_form.assert_called_once_with(
+            self.view.request, 1, "data1"
+        )
+        mock_language_by_language_code.assert_called_once_with("es", self.view.request)
+        mock_get_combinations.assert_called_once_with(1, self.view.request)
+        mock_get_active_project.assert_called_once_with("test_user", self.view.request)
+        mock_get_all_affiliations.assert_called_once_with(self.view.request)

--- a/climmob/views/project_metadata.py
+++ b/climmob/views/project_metadata.py
@@ -10,7 +10,7 @@ from climmob.processes import (
     getProjectMetadataForm,
     modifyProjectMetadataForm,
     getCombinations,
-    get_all_affiliations,
+    get_all_affiliations, languageByLanguageCode,
 )
 from climmob.views.classes import privateView
 from jinja2 import Environment, FileSystemLoader
@@ -18,7 +18,7 @@ import json
 import os
 
 
-class ProjectMetadataForm_view(privateView):
+class ProjectMetadataFormView(privateView):
     def processView(self):
 
         activeProjectUser = self.request.matchdict["user"]
@@ -58,6 +58,7 @@ class ProjectMetadataForm_view(privateView):
                     )
 
                     if not projectMetadataForm:
+                        postData["pmf_lang"] = self.request.locale_name
                         added, message = addProjectMetadataForm(postData, self.request)
                         if not added:
                             error_summary = {"error": message}
@@ -119,12 +120,19 @@ class ShowMetadataForm_view(privateView):
                     return ""
                 else:
                     informationFilled = {}
+                    lang_answer = self.request.locale_name
+                    lang_answer_name = None
+
                     projectMetadataForm = getProjectMetadataForm(
                         self.request, activeProjectId, metadataId
                     )
 
                     if projectMetadataForm:
                         informationFilled = projectMetadataForm["pmf_json"]
+
+                        if projectMetadataForm["pmf_lang"]:
+                            lang_answer = projectMetadataForm["pmf_lang"]
+                            lang_answer_name = languageByLanguageCode(lang_answer,self.request)["lang_name"]
 
                     PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
                     env = Environment(
@@ -193,6 +201,8 @@ class ShowMetadataForm_view(privateView):
                         "inputs": inputs,
                         "form_to_use": metadataForm["metadata_for_technology_options"],
                         "list_of_affiliations": get_all_affiliations(self.request),
+                        "lang_answer": lang_answer,
+                        "lang_answer_name": lang_answer_name
                     }
                     render_temp = template.render(dict)
 

--- a/climmob/views/project_metadata.py
+++ b/climmob/views/project_metadata.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pyramid.httpexceptions import HTTPNotFound, HTTPFound
 
 from climmob.processes import (
@@ -10,7 +12,8 @@ from climmob.processes import (
     getProjectMetadataForm,
     modifyProjectMetadataForm,
     getCombinations,
-    get_all_affiliations, languageByLanguageCode,
+    get_all_affiliations,
+    languageByLanguageCode,
 )
 from climmob.views.classes import privateView
 from jinja2 import Environment, FileSystemLoader
@@ -52,6 +55,7 @@ class ProjectMetadataFormView(privateView):
                     postData = self.getPostDict()
                     postData["project_id"] = activeProjectId
                     postData["pmf_json"] = json.loads(postData["_jsonResult"])
+                    postData["pmf_last_update"] = datetime.now()
 
                     projectMetadataForm = getProjectMetadataForm(
                         self.request, activeProjectId, postData["metadata_id"]
@@ -60,8 +64,8 @@ class ProjectMetadataFormView(privateView):
                     if not projectMetadataForm:
                         postData["pmf_lang"] = self.request.locale_name
                         added, message = addProjectMetadataForm(postData, self.request)
-                        if not added:
-                            error_summary = {"error": message}
+                        # if not added:
+                        #     error_summary = {"error": message}
                     else:
                         edited, message = modifyProjectMetadataForm(
                             self.request,
@@ -70,10 +74,10 @@ class ProjectMetadataFormView(privateView):
                             postData,
                         )
 
-                        if not edited:
-                            error_summary = {"error": message}
+                        # if not edited:
+                        #     error_summary = {"error": message}
 
-                    if not error_summary:
+                    if not message:
 
                         self.request.session.flash(
                             self._("The project metadata was save successfully.")
@@ -88,6 +92,8 @@ class ProjectMetadataFormView(privateView):
                                 _query={"metadataForm": postData["metadata_id"]},
                             )
                         )
+                    else:
+                        self.request.session.flash(message)
         return {
             "activeProject": activeProject,
             "dataworking": dataworking,
@@ -96,7 +102,7 @@ class ProjectMetadataFormView(privateView):
         }
 
 
-class ShowMetadataForm_view(privateView):
+class ShowMetadataFormView(privateView):
     def processView(self):
         activeProjectUser = self.request.matchdict["user"]
         activeProjectCod = self.request.matchdict["project"]
@@ -132,7 +138,9 @@ class ShowMetadataForm_view(privateView):
 
                         if projectMetadataForm["pmf_lang"]:
                             lang_answer = projectMetadataForm["pmf_lang"]
-                            lang_answer_name = languageByLanguageCode(lang_answer,self.request)["lang_name"]
+                            lang_answer_name = languageByLanguageCode(
+                                lang_answer, self.request
+                            )["lang_name"]
 
                     PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
                     env = Environment(
@@ -149,9 +157,9 @@ class ShowMetadataForm_view(privateView):
                     template_table = env.get_template("template_table.jinja2")
                     inputs = env.get_template("metadata_inputs.jinja2")
 
-                    dictionary = self.extract_names_and_types(
-                        json.loads(metadataForm["metadata_json"])
-                    )
+                    # dictionary = self.extract_names_and_types(
+                    #     json.loads(metadataForm["metadata_json"])
+                    # )
 
                     dict_of_technologies_with_synonyms = {}
                     if metadataForm["metadata_for_technology_options"] == 1:
@@ -190,7 +198,6 @@ class ShowMetadataForm_view(privateView):
                         "activeProject": activeProjectData,
                         "Form": json.loads(metadataForm["metadata_json"]),
                         "postData": json.dumps(informationFilled),
-                        "dictionary": json.dumps(dictionary),
                         "_": self._,
                         "request": self.request,
                         "technologies_with_synonyms": json.dumps(
@@ -202,7 +209,7 @@ class ShowMetadataForm_view(privateView):
                         "form_to_use": metadataForm["metadata_for_technology_options"],
                         "list_of_affiliations": get_all_affiliations(self.request),
                         "lang_answer": lang_answer,
-                        "lang_answer_name": lang_answer_name
+                        "lang_answer_name": lang_answer_name,
                     }
                     render_temp = template.render(dict)
 
@@ -210,30 +217,30 @@ class ShowMetadataForm_view(privateView):
 
         return ""
 
-    def extract_names_and_types(self, data, result=None):
-        if result is None:
-            result = []
-
-        if isinstance(data, dict):
-
-            if "name" in data and "type" in data:
-                if "climmob_users" in data:
-                    if data["climmob_users"] == "yes":
-                        result.append(
-                            {
-                                "name": data["name"],
-                                "type": data["type"] + " climmob_users",
-                            }
-                        )
-                else:
-                    result.append({"name": data["name"], "type": data["type"]})
-
-            for key, value in data.items():
-                if isinstance(value, (dict, list)):
-                    self.extract_names_and_types(value, result)
-
-        elif isinstance(data, list):
-            for item in data:
-                self.extract_names_and_types(item, result)
-
-        return result
+    # def extract_names_and_types(self, data, result=None):
+    #     if result is None:
+    #         result = []
+    #
+    #     if isinstance(data, dict):
+    #
+    #         if "name" in data and "type" in data:
+    #             if "climmob_users" in data:
+    #                 if data["climmob_users"] == "yes":
+    #                     result.append(
+    #                         {
+    #                             "name": data["name"],
+    #                             "type": data["type"] + " climmob_users",
+    #                         }
+    #                     )
+    #             else:
+    #                 result.append({"name": data["name"], "type": data["type"]})
+    #
+    #         for key, value in data.items():
+    #             if isinstance(value, (dict, list)):
+    #                 self.extract_names_and_types(value, result)
+    #
+    #     elif isinstance(data, list):
+    #         for item in data:
+    #             self.extract_names_and_types(item, result)
+    #
+    #     return result


### PR DESCRIPTION
#323 Show optional fields only when relevant
Kept the language trial to keep the responses.

Added the date of modification for control
Hide the title that says: Please note that all fields are mandatory unless they include the label “(Optional)”
Put the tag optional on the title of the fields that are required again
 Add the test for the project_metadata
 Refactor of the project metadata on CamelCase